### PR TITLE
Provide obnoxious number of extra snippets

### DIFF
--- a/snippets/sfz.json
+++ b/snippets/sfz.json
@@ -55,4 +55,4186 @@
 		],
 		"description": "SFZ v2 header for defining curves for MIDI CC controls."
 	}
+
+	"SFZv1 amp_keycenter": {
+		"scope": "sfz",
+		"prefix": "amp_keycenter",
+		"body": "amp_keycenter=60$0",
+		"description": "Center key for amplifier keyboard tracking. In this key, the amplifier keyboard tracking will have no effect. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 amp_keytrack": {
+		"scope": "sfz",
+		"prefix": "amp_keytrack",
+		"body": "amp_keytrack=0$0",
+		"description": "Amplifier keyboard tracking (change in amplitude per key) in decibels. Type: float | Range: -96 to 12 dB"
+	},
+	"SFZv1 amp_random": {
+		"scope": "sfz",
+		"prefix": "amp_random",
+		"body": "amp_random=0$0",
+		"description": "Random volume for the region, in decibels. Type: float | Range: 0 to 24 dB"
+	},
+	"SFZv1 amp_velcurve_N": {
+		"scope": "sfz",
+		"prefix": "amp_velcurve_N",
+		"body": "amp_velcurve_N=Standard curve (see amp_veltrack)$0",
+		"description": "User-defined amplifier velocity curve. Type: float | Range: 0 to 1"
+	},
+	"SFZv1 amp_veltrack": {
+		"scope": "sfz",
+		"prefix": "amp_veltrack",
+		"body": "amp_veltrack=100$0",
+		"description": "Amplifier velocity tracking, represents how much the amplitude changes with incoming note velocity. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 ampeg_attack": {
+		"scope": "sfz",
+		"prefix": "ampeg_attack",
+		"body": "ampeg_attack=0$0",
+		"description": "EG attack time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 ampeg_attackccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_attackccN",
+		"body": "ampeg_attackcc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_decay": {
+		"scope": "sfz",
+		"prefix": "ampeg_decay",
+		"body": "ampeg_decay=0$0",
+		"description": "EG decay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 ampeg_decayccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_decayccN",
+		"body": "ampeg_decaycc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"SFZv1 ampeg_delay": {
+		"scope": "sfz",
+		"prefix": "ampeg_delay",
+		"body": "ampeg_delay=0$0",
+		"description": "EG delay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 ampeg_delayccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_delayccN",
+		"body": "ampeg_delaycc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"SFZv1 ampeg_hold": {
+		"scope": "sfz",
+		"prefix": "ampeg_hold",
+		"body": "ampeg_hold=0$0",
+		"description": "EG hold time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 ampeg_holdccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_holdccN",
+		"body": "ampeg_holdcc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"SFZv1 ampeg_release": {
+		"scope": "sfz",
+		"prefix": "ampeg_release",
+		"body": "ampeg_release=0.001$0",
+		"description": "EG release time (after note release). Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 ampeg_releaseccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_releaseccN",
+		"body": "ampeg_releasecc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_start": {
+		"scope": "sfz",
+		"prefix": "ampeg_start",
+		"body": "ampeg_start=0$0",
+		"description": "Envelope start level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 ampeg_startccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_startccN",
+		"body": "ampeg_startcc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_sustain": {
+		"scope": "sfz",
+		"prefix": "ampeg_sustain",
+		"body": "ampeg_sustain=100$0",
+		"description": "EG sustain level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 ampeg_sustainccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_sustainccN",
+		"body": "ampeg_sustaincc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 ampeg_vel2attack": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2attack",
+		"body": "ampeg_vel2attack=0$0",
+		"description": "Velocity effect on EG attack time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_vel2decay": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2decay",
+		"body": "ampeg_vel2decay=0$0",
+		"description": "Velocity effect on EG decay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_vel2delay": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2delay",
+		"body": "ampeg_vel2delay=0$0",
+		"description": "Velocity effect on EG delay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_vel2hold": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2hold",
+		"body": "ampeg_vel2hold=0$0",
+		"description": "Velocity effect on EG hold time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_vel2release": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2release",
+		"body": "ampeg_vel2release=0$0",
+		"description": "Velocity effect on EG release time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 ampeg_vel2sustain": {
+		"scope": "sfz",
+		"prefix": "ampeg_vel2sustain",
+		"body": "ampeg_vel2sustain=0$0",
+		"description": "Velocity effect on EG sustain level, in percentage. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 amplfo_delay": {
+		"scope": "sfz",
+		"prefix": "amplfo_delay",
+		"body": "amplfo_delay=0$0",
+		"description": "The time before the LFO starts oscillating. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 amplfo_depth": {
+		"scope": "sfz",
+		"prefix": "amplfo_depth",
+		"body": "amplfo_depth=0$0",
+		"description": "LFO depth. Type: float | Range: -10 to 10 dB"
+	},
+	"SFZv1 amplfo_depthccN": {
+		"scope": "sfz",
+		"prefix": "amplfo_depthccN",
+		"body": "amplfo_depthcc${1:N}=0$0",
+		"description": " Type: float | Range: -10 to 10 dB"
+	},
+	"SFZv1 amplfo_depthchanaft": {
+		"scope": "sfz",
+		"prefix": "amplfo_depthchanaft",
+		"body": "amplfo_depthchanaft=0$0",
+		"description": "LFO depth when channel aftertouch MIDI messages are received. Type: float | Range: -10 to 10 dB"
+	},
+	"SFZv1 amplfo_depthpolyaft": {
+		"scope": "sfz",
+		"prefix": "amplfo_depthpolyaft",
+		"body": "amplfo_depthpolyaft=0$0",
+		"description": "LFO depth when polyphonic aftertouch MIDI messages are received. Type: float | Range: -10 to 10 dB"
+	},
+	"SFZv1 amplfo_fade": {
+		"scope": "sfz",
+		"prefix": "amplfo_fade",
+		"body": "amplfo_fade=0$0",
+		"description": "LFO fade-in effect time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 amplfo_freq": {
+		"scope": "sfz",
+		"prefix": "amplfo_freq",
+		"body": "amplfo_freq=0$0",
+		"description": "LFO frequency, in hertz. Type: float | Range: 0 to 20 Hz"
+	},
+	"SFZv1 amplfo_freqccN": {
+		"scope": "sfz",
+		"prefix": "amplfo_freqccN",
+		"body": "amplfo_freqcc${1:N}=0$0",
+		"description": " Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 amplfo_freqchanaft": {
+		"scope": "sfz",
+		"prefix": "amplfo_freqchanaft",
+		"body": "amplfo_freqchanaft=0$0",
+		"description": "LFO frequency change when channel aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 amplfo_freqpolyaft": {
+		"scope": "sfz",
+		"prefix": "amplfo_freqpolyaft",
+		"body": "amplfo_freqpolyaft=0$0",
+		"description": "LFO frequency change when polyphonic aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 bend_down": {
+		"scope": "sfz",
+		"prefix": "bend_down",
+		"body": "bend_down=-200$0",
+		"description": "Pitch bend range when Bend Wheel or Joystick is moved down, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 bend_step": {
+		"scope": "sfz",
+		"prefix": "bend_step",
+		"body": "bend_step=1$0",
+		"description": "Pitch bend step, in cents. Type: integer | Range: 1 to 1200 cents"
+	},
+	"SFZv1 bend_up": {
+		"scope": "sfz",
+		"prefix": "bend_up",
+		"body": "bend_up=200$0",
+		"description": "Pitch bend range when Bend Wheel or Joystick is moved up, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 benddown": {
+		"scope": "sfz",
+		"prefix": "benddown",
+		"body": "benddown=-200$0",
+		"description": "bend_down alias. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 bendstep": {
+		"scope": "sfz",
+		"prefix": "bendstep",
+		"body": "bendstep=1$0",
+		"description": "bend_step alias. Type: integer | Range: 1 to 1200 cents"
+	},
+	"SFZv1 bendup": {
+		"scope": "sfz",
+		"prefix": "bendup",
+		"body": "bendup=200$0",
+		"description": "bend_up alias. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 count": {
+		"scope": "sfz",
+		"prefix": "count",
+		"body": "count=0$0",
+		"description": "The number of times the sample will be played. Type: integer | Range: 0 to 4294967296"
+	},
+	"SFZv1 cutoff_ccN": {
+		"scope": "sfz",
+		"prefix": "cutoff_ccN",
+		"body": "cutoff_cc${1:N}=0$0",
+		"description": "The variation in the cutoff frequency when MIDI continuous controller N is received. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 cutoff_chanaft": {
+		"scope": "sfz",
+		"prefix": "cutoff_chanaft",
+		"body": "cutoff_chanaft=0$0",
+		"description": "The variation in the cutoff frequency when MIDI channel aftertouch messages are received, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 cutoff_polyaft": {
+		"scope": "sfz",
+		"prefix": "cutoff_polyaft",
+		"body": "cutoff_polyaft=0$0",
+		"description": "The variation in the cutoff frequency when MIDI polyphonic aftertouch messages are received, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 cutoff": {
+		"scope": "sfz",
+		"prefix": "cutoff",
+		"body": "cutoff=filter disabled$0",
+		"description": "Sets the cutoff frequency (Hz) of the filters. Type: float | Range: 0 to SampleRate / 2 Hz"
+	},
+	"SFZv1 delay_ccN": {
+		"scope": "sfz",
+		"prefix": "delay_ccN",
+		"body": "delay_cc${1:N}=0$0",
+		"description": "Region delay time after MIDI continuous controller N messages are received. If the region receives a note-off message before delay time, the region won't play. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 delay_random": {
+		"scope": "sfz",
+		"prefix": "delay_random",
+		"body": "delay_random=0$0",
+		"description": "Region random delay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 delay": {
+		"scope": "sfz",
+		"prefix": "delay",
+		"body": "delay=0$0",
+		"description": "Region delay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 effect1": {
+		"scope": "sfz",
+		"prefix": "effect1",
+		"body": "effect1=0$0",
+		"description": "Level of effect1 send, in percentage (reverb in Cakewalk sfz). Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 effect2": {
+		"scope": "sfz",
+		"prefix": "effect2",
+		"body": "effect2=0$0",
+		"description": "Level of effect2 send, in percentage (chorus in Cakewalk sfz). Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 end": {
+		"scope": "sfz",
+		"prefix": "end",
+		"body": "end=unspecified$0",
+		"description": "The endpoint of the sample. If unspecified, the entire sample will play. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 eqN_bw": {
+		"scope": "sfz",
+		"prefix": "eqN_bw",
+		"body": "eqN_bw=1$0",
+		"description": "Bandwidth of the equalizer band, in octaves. Type: float | Range: 0.001 to 4 octaves"
+	},
+	"SFZv1 eqN_bwccX": {
+		"scope": "sfz",
+		"prefix": "eqN_bwccX",
+		"body": "eqN_bwccX=0$0",
+		"description": " Type: float | Range: -4 to 4 octaves"
+	},
+	"SFZv1 eqN_freq": {
+		"scope": "sfz",
+		"prefix": "eqN_freq",
+		"body": "eqN_freq=eq1_freq=50eq1_freq=500eq1_freq=5000$0",
+		"description": "Frequency of the equalizer band, in Hertz. Type: float | Range: 0 to 30000 Hz"
+	},
+	"SFZv1 eqN_freqccX": {
+		"scope": "sfz",
+		"prefix": "eqN_freqccX",
+		"body": "eqN_freqccX=0$0",
+		"description": " Type: float | Range: -30000 to 30000 Hz"
+	},
+	"SFZv1 eqN_gain": {
+		"scope": "sfz",
+		"prefix": "eqN_gain",
+		"body": "eqN_gain=0$0",
+		"description": "Gain of the equalizer band, in decibels. Type: float | Range: -96 to 24 dB"
+	},
+	"SFZv1 eqN_gainccX": {
+		"scope": "sfz",
+		"prefix": "eqN_gainccX",
+		"body": "eqN_gainccX=0$0",
+		"description": " Type: float | Range: -96 to 24 dB"
+	},
+	"SFZv1 eqN_vel2freq": {
+		"scope": "sfz",
+		"prefix": "eqN_vel2freq",
+		"body": "eqN_vel2freq=0$0",
+		"description": "Frequency change of the equalizer band with MIDI velocity, in Hertz. Type: float | Range: -30000 to 30000 Hz"
+	},
+	"SFZv1 eqN_vel2gain": {
+		"scope": "sfz",
+		"prefix": "eqN_vel2gain",
+		"body": "eqN_vel2gain=0$0",
+		"description": "Gain change of the equalizer band with MIDI velocity, in decibels. Type: float | Range: -96 to 24 dB"
+	},
+	"SFZv1 fil_keycenter": {
+		"scope": "sfz",
+		"prefix": "fil_keycenter",
+		"body": "fil_keycenter=60$0",
+		"description": "Center key for filter keyboard tracking. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 fil_keytrack": {
+		"scope": "sfz",
+		"prefix": "fil_keytrack",
+		"body": "fil_keytrack=0$0",
+		"description": "Filter keyboard tracking (change on cutoff for each key) in cents. Type: integer | Range: 0 to 1200 cents"
+	},
+	"SFZv1 fil_random": {
+		"scope": "sfz",
+		"prefix": "fil_random",
+		"body": "fil_random=0$0",
+		"description": "Random value added to the filter cutoff for the region, in cents. Type: integer | Range: 0 to 9600 cents"
+	},
+	"SFZv1 fil_type": {
+		"scope": "sfz",
+		"prefix": "fil_type",
+		"body": "fil_type=lpf_2p$0",
+		"description": "Filter type. Type: string | Range: lpf_1p, hpf_1p, lpf_2p, hpf_2p, bpf_2p, brf_2p, bpf_1p, brf_1p, apf_1p, lpf_2p_sv, hpf_2p_sv, bpf_2p_sv, brf_2p_sv, pkf_2p, lpf_4p, hpf_4p, lpf_6p, hpf_6p, comb, pink, lsh, hsh, peq"
+	},
+	"SFZv1 fil_veltrack": {
+		"scope": "sfz",
+		"prefix": "fil_veltrack",
+		"body": "fil_veltrack=0$0",
+		"description": "Filter velocity tracking, the amount by which the cutoff changes with incoming note velocity, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 fileg_attack": {
+		"scope": "sfz",
+		"prefix": "fileg_attack",
+		"body": "fileg_attack=0$0",
+		"description": "EG attack time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fileg_decay": {
+		"scope": "sfz",
+		"prefix": "fileg_decay",
+		"body": "fileg_decay=0$0",
+		"description": "EG decay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fileg_delay": {
+		"scope": "sfz",
+		"prefix": "fileg_delay",
+		"body": "fileg_delay=0$0",
+		"description": "EG delay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fileg_depth": {
+		"scope": "sfz",
+		"prefix": "fileg_depth",
+		"body": "fileg_depth=0$0",
+		"description": "Envelope depth. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"SFZv1 fileg_hold": {
+		"scope": "sfz",
+		"prefix": "fileg_hold",
+		"body": "fileg_hold=0$0",
+		"description": "EG hold time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fileg_release": {
+		"scope": "sfz",
+		"prefix": "fileg_release",
+		"body": "fileg_release=0$0",
+		"description": "EG release time (after note release). Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fileg_start": {
+		"scope": "sfz",
+		"prefix": "fileg_start",
+		"body": "fileg_start=0$0",
+		"description": "Envelope start level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 fileg_sustain": {
+		"scope": "sfz",
+		"prefix": "fileg_sustain",
+		"body": "fileg_sustain=0$0",
+		"description": "EG sustain level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 fileg_vel2attack": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2attack",
+		"body": "fileg_vel2attack=0$0",
+		"description": "Velocity effect on EG attack time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 fileg_vel2decay": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2decay",
+		"body": "fileg_vel2decay=0$0",
+		"description": "Velocity effect on filter EG decay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 fileg_vel2delay": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2delay",
+		"body": "fileg_vel2delay=0$0",
+		"description": "Velocity effect on filter EG delay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 fileg_vel2depth": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2depth",
+		"body": "fileg_vel2depth=0$0",
+		"description": "Velocity effect on EG depth, in cents for pitch or filter cutoff. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"SFZv1 fileg_vel2hold": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2hold",
+		"body": "fileg_vel2hold=0$0",
+		"description": "Velocity effect on EG hold time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 fileg_vel2release": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2release",
+		"body": "fileg_vel2release=0$0",
+		"description": "Velocity effect on EG release time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 fileg_vel2sustain": {
+		"scope": "sfz",
+		"prefix": "fileg_vel2sustain",
+		"body": "fileg_vel2sustain=0$0",
+		"description": "Velocity effect on EG sustain level, in percentage. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 fillfo_delay": {
+		"scope": "sfz",
+		"prefix": "fillfo_delay",
+		"body": "fillfo_delay=0$0",
+		"description": "The time before the LFO starts oscillating. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fillfo_depth": {
+		"scope": "sfz",
+		"prefix": "fillfo_depth",
+		"body": "fillfo_depth=0$0",
+		"description": "LFO depth. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 fillfo_depthccN": {
+		"scope": "sfz",
+		"prefix": "fillfo_depthccN",
+		"body": "fillfo_depthcc${1:N}=0$0",
+		"description": " Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 fillfo_depthchanaft": {
+		"scope": "sfz",
+		"prefix": "fillfo_depthchanaft",
+		"body": "fillfo_depthchanaft=0$0",
+		"description": "LFO depth when channel aftertouch MIDI messages are received. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 fillfo_depthpolyaft": {
+		"scope": "sfz",
+		"prefix": "fillfo_depthpolyaft",
+		"body": "fillfo_depthpolyaft=0$0",
+		"description": "LFO depth when polyphonic aftertouch MIDI messages are received. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 fillfo_fade": {
+		"scope": "sfz",
+		"prefix": "fillfo_fade",
+		"body": "fillfo_fade=0$0",
+		"description": "LFO fade-in effect time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 fillfo_freq": {
+		"scope": "sfz",
+		"prefix": "fillfo_freq",
+		"body": "fillfo_freq=0$0",
+		"description": "LFO frequency, in hertz. Type: float | Range: 0 to 20 Hz"
+	},
+	"SFZv1 fillfo_freqccN": {
+		"scope": "sfz",
+		"prefix": "fillfo_freqccN",
+		"body": "fillfo_freqcc${1:N}=0$0",
+		"description": " Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 fillfo_freqchanaft": {
+		"scope": "sfz",
+		"prefix": "fillfo_freqchanaft",
+		"body": "fillfo_freqchanaft=0$0",
+		"description": "LFO frequency change when channel aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 fillfo_freqpolyaft": {
+		"scope": "sfz",
+		"prefix": "fillfo_freqpolyaft",
+		"body": "fillfo_freqpolyaft=0$0",
+		"description": "LFO frequency change when polyphonic aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 filtype": {
+		"scope": "sfz",
+		"prefix": "filtype",
+		"body": "filtype=lpf_2p$0",
+		"description": "fil_type alias. Type: string | Range: lpf_1p, hpf_1p, lpf_2p, hpf_2p, bpf_2p, brf_2p, bpf_1p, brf_1p, apf_1p, lpf_2p_sv, hpf_2p_sv, bpf_2p_sv, brf_2p_sv, pkf_2p, lpf_4p, hpf_4p, lpf_6p, hpf_6p, comb, pink, lsh, hsh, peq"
+	},
+	"SFZv1 gain_ccN": {
+		"scope": "sfz",
+		"prefix": "gain_ccN",
+		"body": "gain_cc${1:N}=0$0",
+		"description": "Gain applied on MIDI control N, in decibels. Type: float | Range: -144 to 48 dB"
+	},
+	"SFZv1 group": {
+		"scope": "sfz",
+		"prefix": "group",
+		"body": "group=0$0",
+		"description": "Exclusive group number for this region. Type: integer | Range: -2147483648 to 2147483647"
+	},
+	"SFZv1 hibend": {
+		"scope": "sfz",
+		"prefix": "hibend",
+		"body": "hibend=8192$0",
+		"description": "Defines the range of the last Pitch Bend message required for the region to play. Type: integer | Range: -8192 to 8192"
+	},
+	"SFZv1 hibpm": {
+		"scope": "sfz",
+		"prefix": "hibpm",
+		"body": "hibpm=500$0",
+		"description": "Host tempo value. Type: float | Range: 0 to 500 bpm"
+	},
+	"SFZv1 hiccN": {
+		"scope": "sfz",
+		"prefix": "hiccN",
+		"body": "hicc${1:N}=127$0",
+		"description": "Defines the range of the last MIDI controller N required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 hichan": {
+		"scope": "sfz",
+		"prefix": "hichan",
+		"body": "hichan=16$0",
+		"description": "If incoming notes have a MIDI channel between lochan and hichan, the region will play. Type: integer | Range: 1 to 16"
+	},
+	"SFZv1 hichanaft": {
+		"scope": "sfz",
+		"prefix": "hichanaft",
+		"body": "hichanaft=127$0",
+		"description": "Defines the range of last Channel Aftertouch message required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 hikey": {
+		"scope": "sfz",
+		"prefix": "hikey",
+		"body": "hikey=127$0",
+		"description": "Determine the high boundary of a certain region. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 hipolyaft": {
+		"scope": "sfz",
+		"prefix": "hipolyaft",
+		"body": "hipolyaft=127$0",
+		"description": "Defines the range of last Polyphonic Aftertouch message required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 hirand": {
+		"scope": "sfz",
+		"prefix": "hirand",
+		"body": "hirand=1$0",
+		"description": "The region will play if the random number is equal to or higher than lorand, and lower than hirand. Type: float | Range: 0 to 1"
+	},
+	"SFZv1 hivel": {
+		"scope": "sfz",
+		"prefix": "hivel",
+		"body": "hivel=127$0",
+		"description": "If a note with velocity value equal to or higher than lovel AND equal to or lower than hivel is played, the region will play. Type: integer | Range: 1 to 127"
+	},
+	"SFZv1 key": {
+		"scope": "sfz",
+		"prefix": "key",
+		"body": "key=$0",
+		"description": "Equivalent to using lokey, hikey and pitch_keycenter and setting them all to the same note value. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 lobend": {
+		"scope": "sfz",
+		"prefix": "lobend",
+		"body": "lobend=-8192$0",
+		"description": "Defines the range of the last Pitch Bend message required for the region to play. Type: integer | Range: -8192 to 8192"
+	},
+	"SFZv1 lobpm": {
+		"scope": "sfz",
+		"prefix": "lobpm",
+		"body": "lobpm=0$0",
+		"description": "Host tempo value. Type: float | Range: 0 to 500 bpm"
+	},
+	"SFZv1 loccN": {
+		"scope": "sfz",
+		"prefix": "loccN",
+		"body": "locc${1:N}=0$0",
+		"description": "Defines the range of the last MIDI controller N required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 lochan": {
+		"scope": "sfz",
+		"prefix": "lochan",
+		"body": "lochan=1$0",
+		"description": "If incoming notes have a MIDI channel between lochan and hichan, the region will play. Type: integer | Range: 1 to 16"
+	},
+	"SFZv1 lochanaft": {
+		"scope": "sfz",
+		"prefix": "lochanaft",
+		"body": "lochanaft=0$0",
+		"description": "Defines the range of last Channel Aftertouch message required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 lokey": {
+		"scope": "sfz",
+		"prefix": "lokey",
+		"body": "lokey=0$0",
+		"description": "Determine the low boundary of a certain region. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 loop_end": {
+		"scope": "sfz",
+		"prefix": "loop_end",
+		"body": "loop_end=0$0",
+		"description": "The loop end point, in samples. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 loop_mode": {
+		"scope": "sfz",
+		"prefix": "loop_mode",
+		"body": "loop_mode=no_loop for samples without a loop defined, loop_continuous for samples with defined loop(s).$0",
+		"description": "Allows playing samples with loops defined in the unlooped mode. Type: string | Range: no_loop, one_shot, loop_continuous, loop_sustain"
+	},
+	"SFZv1 loop_start": {
+		"scope": "sfz",
+		"prefix": "loop_start",
+		"body": "loop_start=0$0",
+		"description": "The loop start point, in samples. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 loopend": {
+		"scope": "sfz",
+		"prefix": "loopend",
+		"body": "loopend=0$0",
+		"description": "loop_end alias. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 loopmode": {
+		"scope": "sfz",
+		"prefix": "loopmode",
+		"body": "loopmode=no_loop for samples without a loop defined, loop_continuous for samples with defined loop(s).$0",
+		"description": "loop_mode alias. Type: string | Range: no_loop, one_shot, loop_continuous, loop_sustain"
+	},
+	"SFZv1 loopstart": {
+		"scope": "sfz",
+		"prefix": "loopstart",
+		"body": "loopstart=0$0",
+		"description": "loop_start alias. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 lopolyaft": {
+		"scope": "sfz",
+		"prefix": "lopolyaft",
+		"body": "lopolyaft=0$0",
+		"description": "Defines the range of last Polyphonic Aftertouch message required for the region to play. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 lorand": {
+		"scope": "sfz",
+		"prefix": "lorand",
+		"body": "lorand=0$0",
+		"description": "The region will play if the random number is equal to or higher than lorand, and lower than hirand. Type: float | Range: 0 to 1"
+	},
+	"SFZv1 lovel": {
+		"scope": "sfz",
+		"prefix": "lovel",
+		"body": "lovel=1$0",
+		"description": "If a note with velocity value equal to or higher than lovel AND equal to or lower than hivel is played, the region will play. Type: integer | Range: 1 to 127"
+	},
+	"SFZv1 off_by": {
+		"scope": "sfz",
+		"prefix": "off_by",
+		"body": "off_by=0$0",
+		"description": "Region off group. Type: integer | Range: -2147483648 to 2147483647"
+	},
+	"SFZv1 off_mode": {
+		"scope": "sfz",
+		"prefix": "off_mode",
+		"body": "off_mode=fast$0",
+		"description": "Region off mode. Type: string | Range: fast, normal, time"
+	},
+	"SFZv1 offby": {
+		"scope": "sfz",
+		"prefix": "offby",
+		"body": "offby=0$0",
+		"description": "off_by alias. Type: integer | Range: -2147483648 to 2147483647"
+	},
+	"SFZv1 offset_ccN": {
+		"scope": "sfz",
+		"prefix": "offset_ccN",
+		"body": "offset_cc${1:N}=0$0",
+		"description": "The offset used to play the sample according to last position of MIDI continuous controller N. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 offset_random": {
+		"scope": "sfz",
+		"prefix": "offset_random",
+		"body": "offset_random=0$0",
+		"description": "Random offset added to the region offset. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 offset": {
+		"scope": "sfz",
+		"prefix": "offset",
+		"body": "offset=0$0",
+		"description": "The offset used to play the sample. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv1 on_hiccN": {
+		"scope": "sfz",
+		"prefix": "on_hiccN",
+		"body": "on_hicc${1:N}=-1$0",
+		"description": "If a MIDI control message with a value between on_loccN and on_hiccN is received, the region will play. Default value is -1, it means unassigned. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 on_loccN": {
+		"scope": "sfz",
+		"prefix": "on_loccN",
+		"body": "on_locc${1:N}=-1$0",
+		"description": "If a MIDI control message with a value between on_loccN and on_hiccN is received, the region will play. Default value is -1, it means unassigned. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 output": {
+		"scope": "sfz",
+		"prefix": "output",
+		"body": "output=0$0",
+		"description": "The stereo output number for this region. Type: integer | Range: 0 to 1024"
+	},
+	"SFZv1 pan": {
+		"scope": "sfz",
+		"prefix": "pan",
+		"body": "pan=0$0",
+		"description": "The panoramic position for the region. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 pitch_keycenter": {
+		"scope": "sfz",
+		"prefix": "pitch_keycenter",
+		"body": "pitch_keycenter=60$0",
+		"description": "Root key for the sample. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 pitch_keytrack": {
+		"scope": "sfz",
+		"prefix": "pitch_keytrack",
+		"body": "pitch_keytrack=100$0",
+		"description": "Within the region, this value defines how much the pitch changes with every note. Type: integer | Range: -1200 to 1200"
+	},
+	"SFZv1 pitch_random": {
+		"scope": "sfz",
+		"prefix": "pitch_random",
+		"body": "pitch_random=0$0",
+		"description": "Random tuning for the region, in cents. Type: integer | Range: 0 to 9600 cents"
+	},
+	"SFZv1 pitch_veltrack": {
+		"scope": "sfz",
+		"prefix": "pitch_veltrack",
+		"body": "pitch_veltrack=0$0",
+		"description": "Pitch velocity tracking, represents how much the pitch changes with incoming note velocity, in cents. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv1 pitcheg_attack": {
+		"scope": "sfz",
+		"prefix": "pitcheg_attack",
+		"body": "pitcheg_attack=0$0",
+		"description": "EG attack time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitcheg_decay": {
+		"scope": "sfz",
+		"prefix": "pitcheg_decay",
+		"body": "pitcheg_decay=0$0",
+		"description": "EG decay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitcheg_delay": {
+		"scope": "sfz",
+		"prefix": "pitcheg_delay",
+		"body": "pitcheg_delay=0$0",
+		"description": "EG delay time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitcheg_depth": {
+		"scope": "sfz",
+		"prefix": "pitcheg_depth",
+		"body": "pitcheg_depth=0$0",
+		"description": "Envelope depth. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"SFZv1 pitcheg_hold": {
+		"scope": "sfz",
+		"prefix": "pitcheg_hold",
+		"body": "pitcheg_hold=0$0",
+		"description": "EG hold time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitcheg_release": {
+		"scope": "sfz",
+		"prefix": "pitcheg_release",
+		"body": "pitcheg_release=0$0",
+		"description": "EG release time (after note release). Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitcheg_start": {
+		"scope": "sfz",
+		"prefix": "pitcheg_start",
+		"body": "pitcheg_start=0$0",
+		"description": "Envelope start level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 pitcheg_sustain": {
+		"scope": "sfz",
+		"prefix": "pitcheg_sustain",
+		"body": "pitcheg_sustain=0$0",
+		"description": "EG sustain level, in percentage. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv1 pitcheg_vel2attack": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2attack",
+		"body": "pitcheg_vel2attack=0$0",
+		"description": "Velocity effect on EG attack time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 pitcheg_vel2decay": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2decay",
+		"body": "pitcheg_vel2decay=0$0",
+		"description": "Velocity effect on EG decay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 pitcheg_vel2delay": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2delay",
+		"body": "pitcheg_vel2delay=0$0",
+		"description": "Velocity effect on EG delay time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 pitcheg_vel2depth": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2depth",
+		"body": "pitcheg_vel2depth=0$0",
+		"description": "Velocity effect on EG depth, in cents for pitch or filter cutoff. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"SFZv1 pitcheg_vel2hold": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2hold",
+		"body": "pitcheg_vel2hold=0$0",
+		"description": "Velocity effect on EG hold time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 pitcheg_vel2release": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2release",
+		"body": "pitcheg_vel2release=0$0",
+		"description": "Velocity effect on EG release time. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv1 pitcheg_vel2sustain": {
+		"scope": "sfz",
+		"prefix": "pitcheg_vel2sustain",
+		"body": "pitcheg_vel2sustain=0$0",
+		"description": "Velocity effect on EG sustain level, in percentage. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 pitchlfo_delay": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_delay",
+		"body": "pitchlfo_delay=0$0",
+		"description": "The time before the LFO starts oscillating. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitchlfo_depth": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_depth",
+		"body": "pitchlfo_depth=0$0",
+		"description": "LFO depth. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 pitchlfo_depthccN": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_depthccN",
+		"body": "pitchlfo_depthcc${1:N}=0$0",
+		"description": " Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 pitchlfo_depthchanaft": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_depthchanaft",
+		"body": "pitchlfo_depthchanaft=0$0",
+		"description": "LFO depth when channel aftertouch MIDI messages are received. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 pitchlfo_depthpolyaft": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_depthpolyaft",
+		"body": "pitchlfo_depthpolyaft=0$0",
+		"description": "LFO depth when polyphonic aftertouch MIDI messages are received. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv1 pitchlfo_fade": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_fade",
+		"body": "pitchlfo_fade=0$0",
+		"description": "LFO fade-in effect time. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv1 pitchlfo_freq": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_freq",
+		"body": "pitchlfo_freq=0$0",
+		"description": "LFO frequency, in hertz. Type: float | Range: 0 to 20 Hz"
+	},
+	"SFZv1 pitchlfo_freqccN": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_freqccN",
+		"body": "pitchlfo_freqcc${1:N}=0$0",
+		"description": " Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 pitchlfo_freqchanaft": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_freqchanaft",
+		"body": "pitchlfo_freqchanaft=0$0",
+		"description": "LFO frequency change when channel aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 pitchlfo_freqpolyaft": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_freqpolyaft",
+		"body": "pitchlfo_freqpolyaft=0$0",
+		"description": "LFO frequency change when polyphonic aftertouch MIDI messages are received, in Hertz. Type: float | Range: -200 to 200 Hz"
+	},
+	"SFZv1 position": {
+		"scope": "sfz",
+		"prefix": "position",
+		"body": "position=0$0",
+		"description": "Only operational for stereo samples, position defines the position in the stereo field of a stereo signal, after channel mixing as defined in the width opcode. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 resonance": {
+		"scope": "sfz",
+		"prefix": "resonance",
+		"body": "resonance=0$0",
+		"description": "The filter cutoff resonance value, in decibels. Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv1 rt_decay": {
+		"scope": "sfz",
+		"prefix": "rt_decay",
+		"body": "rt_decay=0$0",
+		"description": "Applies only to regions that triggered through trigger=release. The volume decrease (in decibels) per seconds after the note has been attacked. Type: float | Range: 0 to 200 dB"
+	},
+	"SFZv1 sample": {
+		"scope": "sfz",
+		"prefix": "sample",
+		"body": "sample=$0",
+		"description": "Defines which sample file the region will play. Type: string | Range: N/A"
+	},
+	"SFZv1 seq_length": {
+		"scope": "sfz",
+		"prefix": "seq_length",
+		"body": "seq_length=1$0",
+		"description": "Sequence length, used together with seq_position to use samples as round robins. Type: integer | Range: 1 to 100"
+	},
+	"SFZv1 seq_position": {
+		"scope": "sfz",
+		"prefix": "seq_position",
+		"body": "seq_position=1$0",
+		"description": "Sequence position. The region will play if the internal sequence counter is equal to seq_position. Type: integer | Range: 1 to 100"
+	},
+	"SFZv1 sw_down": {
+		"scope": "sfz",
+		"prefix": "sw_down",
+		"body": "sw_down=0$0",
+		"description": "Enables the region to play if the key equal to sw_down value is depressed. Key has to be in the range specified by sw_lokey and sw_hikey. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_hikey": {
+		"scope": "sfz",
+		"prefix": "sw_hikey",
+		"body": "sw_hikey=127$0",
+		"description": "Defines the range of the keyboard to be used as trigger selectors for the sw_last opcode. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_last": {
+		"scope": "sfz",
+		"prefix": "sw_last",
+		"body": "sw_last=0$0",
+		"description": "Enables the region to play if the last key pressed in the range specified by sw_lokey and sw_hikey is equal to the sw_last value. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_lokey": {
+		"scope": "sfz",
+		"prefix": "sw_lokey",
+		"body": "sw_lokey=0$0",
+		"description": "Defines the range of the keyboard to be used as trigger selectors for the sw_last opcode. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_previous": {
+		"scope": "sfz",
+		"prefix": "sw_previous",
+		"body": "sw_previous=$0",
+		"description": "Previous note value. The region will play if last note-on message was equal to sw_previous value. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_up": {
+		"scope": "sfz",
+		"prefix": "sw_up",
+		"body": "sw_up=0$0",
+		"description": "Enables the region to play if the key equal to sw_up value is not depressed. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 sw_vel": {
+		"scope": "sfz",
+		"prefix": "sw_vel",
+		"body": "sw_vel=current$0",
+		"description": "Allows overriding the velocity for the region with the velocity of the previous note. Type: string | Range: current, previous"
+	},
+	"SFZv1 sync_beats": {
+		"scope": "sfz",
+		"prefix": "sync_beats",
+		"body": "sync_beats=0$0",
+		"description": "Region playing synchronization to host position. Type: float | Range: 0 to 32 beats"
+	},
+	"SFZv1 sync_offset": {
+		"scope": "sfz",
+		"prefix": "sync_offset",
+		"body": "sync_offset=0$0",
+		"description": "Region playing synchronization to host position offset. Type: float | Range: 0 to 32 beats"
+	},
+	"SFZv1 transpose": {
+		"scope": "sfz",
+		"prefix": "transpose",
+		"body": "transpose=0$0",
+		"description": "The transposition value for this region which will be applied to the sample. Type: integer | Range: -127 to 127"
+	},
+	"SFZv1 trigger": {
+		"scope": "sfz",
+		"prefix": "trigger",
+		"body": "trigger=attack$0",
+		"description": "Sets the trigger which will be used for the sample to play. Type: string | Range: attack, release, first, legato, release_key"
+	},
+	"SFZv1 tune": {
+		"scope": "sfz",
+		"prefix": "tune",
+		"body": "tune=0$0",
+		"description": "The fine tuning for the sample, in cents. Type: integer | Range: -100 to 100 cents"
+	},
+	"SFZv1 volume": {
+		"scope": "sfz",
+		"prefix": "volume",
+		"body": "volume=0$0",
+		"description": "The volume for the region, in decibels. Type: float | Range: -144 to 6 dB"
+	},
+	"SFZv1 width": {
+		"scope": "sfz",
+		"prefix": "width",
+		"body": "width=100$0",
+		"description": "Only operational for stereo samples, width defines the amount of channel mixing applied to play the sample. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv1 xf_cccurve": {
+		"scope": "sfz",
+		"prefix": "xf_cccurve",
+		"body": "xf_cccurve=power$0",
+		"description": "MIDI controllers crossfade curve for the region. Type: string | Range: gain, power"
+	},
+	"SFZv1 xf_keycurve": {
+		"scope": "sfz",
+		"prefix": "xf_keycurve",
+		"body": "xf_keycurve=power$0",
+		"description": "Keyboard crossfade curve for the region. Type: string | Range: gain, power"
+	},
+	"SFZv1 xf_velcurve": {
+		"scope": "sfz",
+		"prefix": "xf_velcurve",
+		"body": "xf_velcurve=power$0",
+		"description": "Velocity crossfade curve for the region. Type: string | Range: gain, power"
+	},
+	"SFZv1 xfin_hiccN": {
+		"scope": "sfz",
+		"prefix": "xfin_hiccN",
+		"body": "xfin_hicc${1:N}=0$0",
+		"description": "Fade in control based on MIDI CC. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfin_hikey": {
+		"scope": "sfz",
+		"prefix": "xfin_hikey",
+		"body": "xfin_hikey=0$0",
+		"description": "Fade in control based on MIDI note (keyboard position). Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfin_hivel": {
+		"scope": "sfz",
+		"prefix": "xfin_hivel",
+		"body": "xfin_hivel=0$0",
+		"description": "Fade in control based on velocity. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfin_loccN": {
+		"scope": "sfz",
+		"prefix": "xfin_loccN",
+		"body": "xfin_locc${1:N}=0$0",
+		"description": "Fade in control based on MIDI CC. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfin_lokey": {
+		"scope": "sfz",
+		"prefix": "xfin_lokey",
+		"body": "xfin_lokey=0$0",
+		"description": "Fade in control based on MIDI note (keyboard position). Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfin_lovel": {
+		"scope": "sfz",
+		"prefix": "xfin_lovel",
+		"body": "xfin_lovel=0$0",
+		"description": "Fade in control based on velocity. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfout_hiccN": {
+		"scope": "sfz",
+		"prefix": "xfout_hiccN",
+		"body": "xfout_hicc${1:N}=0$0",
+		"description": "Fade out control based on MIDI CC. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfout_hikey": {
+		"scope": "sfz",
+		"prefix": "xfout_hikey",
+		"body": "xfout_hikey=127$0",
+		"description": "Fade out control based on MIDI note number (keyboard position). Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfout_hivel": {
+		"scope": "sfz",
+		"prefix": "xfout_hivel",
+		"body": "xfout_hivel=127$0",
+		"description": "Fade out control, based on velocity. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfout_loccN": {
+		"scope": "sfz",
+		"prefix": "xfout_loccN",
+		"body": "xfout_locc${1:N}=0$0",
+		"description": "Fade out control based on MIDI CC. Type: integer | Range: 0 to 127"
+	},
+	"SFZv1 xfout_lokey": {
+		"scope": "sfz",
+		"prefix": "xfout_lokey",
+		"body": "xfout_lokey=127$0",
+		"description": "Fade out control based on MIDI note number (keyboard position). Type: integer | Range: 0 to 127"
+	},
+
+	"SFZv2 ampeg_attack_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_attack_onccN",
+		"body": "ampeg_attack_oncc${1:N}=0$0",
+		"description": "ampeg_attackccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv2 ampeg_decay_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_decay_onccN",
+		"body": "ampeg_decay_oncc${1:N}=0$0",
+		"description": "ampeg_decayccN alias. Type: float | Range: -100 to 100"
+	},
+	"SFZv2 ampeg_delay_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_delay_onccN",
+		"body": "ampeg_delay_oncc${1:N}=0$0",
+		"description": "ampeg_delayccN alias. Type: float | Range: -100 to 100"
+	},
+	"SFZv2 ampeg_hold_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_hold_onccN",
+		"body": "ampeg_hold_oncc${1:N}=0$0",
+		"description": "ampeg_holdccN alias. Type: float | Range: -100 to 100"
+	},
+	"SFZv2 ampeg_release_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_release_onccN",
+		"body": "ampeg_release_oncc${1:N}=0$0",
+		"description": "ampeg_releaseccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv2 ampeg_start_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_start_onccN",
+		"body": "ampeg_start_oncc${1:N}=0$0",
+		"description": "ampeg_startccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"SFZv2 ampeg_sustain_onccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_sustain_onccN",
+		"body": "ampeg_sustain_oncc${1:N}=0$0",
+		"description": "ampeg_sustainccN alias. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv2 amplfo_depth_onccN": {
+		"scope": "sfz",
+		"prefix": "amplfo_depth_onccN",
+		"body": "amplfo_depth_oncc${1:N}=0$0",
+		"description": "amplfo_depthccN alias. Type: float | Range: -10 to 10 dB"
+	},
+	"SFZv2 bend_smooth": {
+		"scope": "sfz",
+		"prefix": "bend_smooth",
+		"body": "bend_smooth=0$0",
+		"description": "Pitch bend smoothness. Adds “inertia” to pitch bends, so fast movements of the pitch bend wheel will have a delayed effect on the pitch change. Type: float | Range: 0 to  ms"
+	},
+	"SFZv2 bend_stepdown": {
+		"scope": "sfz",
+		"prefix": "bend_stepdown",
+		"body": "bend_stepdown=1$0",
+		"description": "Pitch bend step, in cents, for downward pitch bends. Type: integer | Range: 1 to 1200 cents"
+	},
+	"SFZv2 bend_stepup": {
+		"scope": "sfz",
+		"prefix": "bend_stepup",
+		"body": "bend_stepup=1$0",
+		"description": "Pitch bend step, in cents, applied to upwards bends only. Type: integer | Range: 1 to 1200 cents"
+	},
+	"SFZv2 bus": {
+		"scope": "sfz",
+		"prefix": "bus",
+		"body": "bus=main$0",
+		"description": "The target bus for the effect. Type: string | Range: main, aux1, aux2, aux3, aux4, aux5, aux6, aux7, aux8, fx1, fx2, fx3, fx4, midi"
+	},
+	"SFZv2 cutoff_curveccN": {
+		"scope": "sfz",
+		"prefix": "cutoff_curveccN",
+		"body": "cutoff_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255 cents"
+	},
+	"SFZv2 cutoff_onccN": {
+		"scope": "sfz",
+		"prefix": "cutoff_onccN",
+		"body": "cutoff_oncc${1:N}=0$0",
+		"description": "cutoff_ccN alias. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv2 cutoff_random": {
+		"scope": "sfz",
+		"prefix": "cutoff_random",
+		"body": "cutoff_random=0$0",
+		"description": "fil_random alias. Type: integer | Range: 0 to 9600 cents"
+	},
+	"SFZv2 cutoff_smoothccN": {
+		"scope": "sfz",
+		"prefix": "cutoff_smoothccN",
+		"body": "cutoff_smoothcc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to  ms"
+	},
+	"SFZv2 cutoff_stepccN": {
+		"scope": "sfz",
+		"prefix": "cutoff_stepccN",
+		"body": "cutoff_stepcc${1:N}=0$0",
+		"description": " Type: integer | Range: 0 to"
+	},
+	"SFZv2 cutoff2_ccN": {
+		"scope": "sfz",
+		"prefix": "cutoff2_ccN",
+		"body": "cutoff2_cc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_chanaft": {
+		"scope": "sfz",
+		"prefix": "cutoff2_chanaft",
+		"body": "cutoff2_chanaft=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_curveccN": {
+		"scope": "sfz",
+		"prefix": "cutoff2_curveccN",
+		"body": "cutoff2_curvecc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_onccN": {
+		"scope": "sfz",
+		"prefix": "cutoff2_onccN",
+		"body": "cutoff2_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_polyaft": {
+		"scope": "sfz",
+		"prefix": "cutoff2_polyaft",
+		"body": "cutoff2_polyaft=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_smoothccN": {
+		"scope": "sfz",
+		"prefix": "cutoff2_smoothccN",
+		"body": "cutoff2_smoothcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2_stepccN": {
+		"scope": "sfz",
+		"prefix": "cutoff2_stepccN",
+		"body": "cutoff2_stepcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 cutoff2": {
+		"scope": "sfz",
+		"prefix": "cutoff2",
+		"body": "cutoff2=filter disabled$0",
+		"description": "cutoff alias. Type: float | Range: 0 to SampleRate / 2 Hz"
+	},
+	"SFZv2 default_path": {
+		"scope": "sfz",
+		"prefix": "default_path",
+		"body": "default_path=$0",
+		"description": "Default file path. Type: string | Range: N/A"
+	},
+	"SFZv2 #define": {
+		"scope": "sfz",
+		"prefix": "#define",
+		"body": "#define=$0",
+		"description": "Creates a variable and gives it a value. Type: string | Range: N/A"
+	},
+	"SFZv2 delay_beats": {
+		"scope": "sfz",
+		"prefix": "delay_beats",
+		"body": "delay_beats=$0",
+		"description": "Delays the start of the region until a certain amount of musical beats are passed. Type: float | Range: N/A"
+	},
+	"SFZv2 delay_onccN": {
+		"scope": "sfz",
+		"prefix": "delay_onccN",
+		"body": "delay_oncc${1:N}=0$0",
+		"description": "delay_ccN alias. Type: float | Range: 0 to 100 seconds"
+	},
+	"SFZv2 delay_samples_onccN": {
+		"scope": "sfz",
+		"prefix": "delay_samples_onccN",
+		"body": "delay_samples_oncc${1:N}=$0",
+		"description": " Type: integer | Range: N/A"
+	},
+	"SFZv2 delay_samples": {
+		"scope": "sfz",
+		"prefix": "delay_samples",
+		"body": "delay_samples=$0",
+		"description": "Allows the region playback to be postponed for the specified time, measured in samples (and therefore dependent on current sample rate). Type: integer | Range: N/A"
+	},
+	"SFZv2 direction": {
+		"scope": "sfz",
+		"prefix": "direction",
+		"body": "direction=forward$0",
+		"description": "The direction in which the sample is to be played. Type: string | Range: forward, reverse"
+	},
+	"SFZv2 effect3": {
+		"scope": "sfz",
+		"prefix": "effect3",
+		"body": "effect3=0$0",
+		"description": "Gain of the region's send into the 3rd effect bus. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv2 effect4": {
+		"scope": "sfz",
+		"prefix": "effect4",
+		"body": "effect4=0$0",
+		"description": "Gain of the region's send into the 4th effect bus. Type: float | Range: 0 to 100 %"
+	},
+	"SFZv2 egN_amplitude_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_amplitude_onccX",
+		"body": "egN_amplitude_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_amplitude": {
+		"scope": "sfz",
+		"prefix": "egN_amplitude",
+		"body": "egN_amplitude=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_curveX": {
+		"scope": "sfz",
+		"prefix": "egN_curveX",
+		"body": "egN_curveX=$0",
+		"description": "Instructs the player to use a curve shape defined under a curve header for the specified envelope segment. Type:  | Range: N/A"
+	},
+	"SFZv2 egN_cutoff_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_cutoff_onccX",
+		"body": "egN_cutoff_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_cutoff": {
+		"scope": "sfz",
+		"prefix": "egN_cutoff",
+		"body": "egN_cutoff=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_cutoff2_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_cutoff2_onccX",
+		"body": "egN_cutoff2_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_cutoff2": {
+		"scope": "sfz",
+		"prefix": "egN_cutoff2",
+		"body": "egN_cutoff2=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_depth_lfoX": {
+		"scope": "sfz",
+		"prefix": "egN_depth_lfoX",
+		"body": "egN_depth_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_depthadd_lfoX": {
+		"scope": "sfz",
+		"prefix": "egN_depthadd_lfoX",
+		"body": "egN_depthadd_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXbw_onccY": {
+		"scope": "sfz",
+		"prefix": "egN_eqXbw_onccY",
+		"body": "egN_eqXbw_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXbw": {
+		"scope": "sfz",
+		"prefix": "egN_eqXbw",
+		"body": "egN_eqXbw=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXfreq_onccY": {
+		"scope": "sfz",
+		"prefix": "egN_eqXfreq_onccY",
+		"body": "egN_eqXfreq_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXfreq": {
+		"scope": "sfz",
+		"prefix": "egN_eqXfreq",
+		"body": "egN_eqXfreq=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXgain_onccY": {
+		"scope": "sfz",
+		"prefix": "egN_eqXgain_onccY",
+		"body": "egN_eqXgain_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_eqXgain": {
+		"scope": "sfz",
+		"prefix": "egN_eqXgain",
+		"body": "egN_eqXgain=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_freq_lfoX": {
+		"scope": "sfz",
+		"prefix": "egN_freq_lfoX",
+		"body": "egN_freq_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_levelX_onccY": {
+		"scope": "sfz",
+		"prefix": "egN_levelX_onccY",
+		"body": "egN_levelX_onccY=0$0",
+		"description": " Type: float | Range: -1 to 1"
+	},
+	"SFZv2 egN_levelX": {
+		"scope": "sfz",
+		"prefix": "egN_levelX",
+		"body": "egN_levelX=0$0",
+		"description": "Sets the envelope level at a specific point in envelope number N. Type: float | Range: -1 to 1"
+	},
+	"SFZv2 egN_loop_count": {
+		"scope": "sfz",
+		"prefix": "egN_loop_count",
+		"body": "egN_loop_count=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_loop": {
+		"scope": "sfz",
+		"prefix": "egN_loop",
+		"body": "egN_loop=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pan_curve": {
+		"scope": "sfz",
+		"prefix": "egN_pan_curve",
+		"body": "egN_pan_curve=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pan_curveccX": {
+		"scope": "sfz",
+		"prefix": "egN_pan_curveccX",
+		"body": "egN_pan_curveccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pan_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_pan_onccX",
+		"body": "egN_pan_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pan": {
+		"scope": "sfz",
+		"prefix": "egN_pan",
+		"body": "egN_pan=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pitch_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_pitch_onccX",
+		"body": "egN_pitch_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_pitch": {
+		"scope": "sfz",
+		"prefix": "egN_pitch",
+		"body": "egN_pitch=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_points": {
+		"scope": "sfz",
+		"prefix": "egN_points",
+		"body": "egN_points=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_resonance_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_resonance_onccX",
+		"body": "egN_resonance_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_resonance": {
+		"scope": "sfz",
+		"prefix": "egN_resonance",
+		"body": "egN_resonance=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_resonance2_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_resonance2_onccX",
+		"body": "egN_resonance2_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_resonance2": {
+		"scope": "sfz",
+		"prefix": "egN_resonance2",
+		"body": "egN_resonance2=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_shapeX": {
+		"scope": "sfz",
+		"prefix": "egN_shapeX",
+		"body": "egN_shapeX=0$0",
+		"description": " Type: float | Range: N/A"
+	},
+	"SFZv2 egN_sustain": {
+		"scope": "sfz",
+		"prefix": "egN_sustain",
+		"body": "egN_sustain=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_timeX_onccY": {
+		"scope": "sfz",
+		"prefix": "egN_timeX_onccY",
+		"body": "egN_timeX_onccY=$0",
+		"description": " Type: float | Range: N/A"
+	},
+	"SFZv2 egN_timeX": {
+		"scope": "sfz",
+		"prefix": "egN_timeX",
+		"body": "egN_timeX=$0",
+		"description": " Type: float | Range: N/A"
+	},
+	"SFZv2 egN_volume_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_volume_onccX",
+		"body": "egN_volume_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_volume": {
+		"scope": "sfz",
+		"prefix": "egN_volume",
+		"body": "egN_volume=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_width_onccX": {
+		"scope": "sfz",
+		"prefix": "egN_width_onccX",
+		"body": "egN_width_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 egN_width": {
+		"scope": "sfz",
+		"prefix": "egN_width",
+		"body": "egN_width=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 eqN_bw_onccX": {
+		"scope": "sfz",
+		"prefix": "eqN_bw_onccX",
+		"body": "eqN_bw_onccX=0$0",
+		"description": "eqN_bwccX alias. Type: float | Range: -4 to 4 octaves"
+	},
+	"SFZv2 eqN_freq_onccX": {
+		"scope": "sfz",
+		"prefix": "eqN_freq_onccX",
+		"body": "eqN_freq_onccX=0$0",
+		"description": "eqN_freqccX alias. Type: float | Range: -30000 to 30000 Hz"
+	},
+	"SFZv2 eqN_gain_onccX": {
+		"scope": "sfz",
+		"prefix": "eqN_gain_onccX",
+		"body": "eqN_gain_onccX=0$0",
+		"description": "eqN_gainccX alias. Type: float | Range: -96 to 24 dB"
+	},
+	"SFZv2 eqN_type": {
+		"scope": "sfz",
+		"prefix": "eqN_type",
+		"body": "eqN_type=peak$0",
+		"description": "Sets the type of EQ filter. Type: string | Range: peak, lshelf, hshelf"
+	},
+	"SFZv2 fil2_keycenter": {
+		"scope": "sfz",
+		"prefix": "fil2_keycenter",
+		"body": "fil2_keycenter=60$0",
+		"description": "fil_keycenter alias. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 fil2_keytrack": {
+		"scope": "sfz",
+		"prefix": "fil2_keytrack",
+		"body": "fil2_keytrack=0$0",
+		"description": "fil_keytrack alias. Type: integer | Range: 0 to 1200 cents"
+	},
+	"SFZv2 fil2_type": {
+		"scope": "sfz",
+		"prefix": "fil2_type",
+		"body": "fil2_type=lpf_2p$0",
+		"description": "fil_type alias. Type: string | Range: lpf_1p, hpf_1p, lpf_2p, hpf_2p, bpf_2p, brf_2p, bpf_1p, brf_1p, apf_1p, lpf_2p_sv, hpf_2p_sv, bpf_2p_sv, brf_2p_sv, pkf_2p, lpf_4p, hpf_4p, lpf_6p, hpf_6p, comb, pink, lsh, hsh, peq"
+	},
+	"SFZv2 fil2_veltrack": {
+		"scope": "sfz",
+		"prefix": "fil2_veltrack",
+		"body": "fil2_veltrack=0$0",
+		"description": "fil_veltrack alias. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"SFZv2 fillfo_depth_onccN": {
+		"scope": "sfz",
+		"prefix": "fillfo_depth_onccN",
+		"body": "fillfo_depth_oncc${1:N}=0$0",
+		"description": "fillfo_depthccN alias. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv2 gain_onccN": {
+		"scope": "sfz",
+		"prefix": "gain_onccN",
+		"body": "gain_oncc${1:N}=0$0",
+		"description": "gain_ccN alias. Type: float | Range: -144 to 48 dB"
+	},
+	"SFZv2 hiprog": {
+		"scope": "sfz",
+		"prefix": "hiprog",
+		"body": "hiprog=127$0",
+		"description": "The region plays when the MIDI program number is between loprog and hiprog. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 hitimer": {
+		"scope": "sfz",
+		"prefix": "hitimer",
+		"body": "hitimer=$0",
+		"description": "Region plays if timer is between lotimer and hitimer. Type: float | Range: N/A"
+	},
+	"SFZv2 lfoN_amplitude_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_amplitude_onccX",
+		"body": "lfoN_amplitude_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_amplitude_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_amplitude_smoothccX",
+		"body": "lfoN_amplitude_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_amplitude_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_amplitude_stepccX",
+		"body": "lfoN_amplitude_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_amplitude": {
+		"scope": "sfz",
+		"prefix": "lfoN_amplitude",
+		"body": "lfoN_amplitude=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_count": {
+		"scope": "sfz",
+		"prefix": "lfoN_count",
+		"body": "lfoN_count=$0",
+		"description": "Number of LFO repetitions for LFO N before the LFO stops. Type: integer | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff_onccX",
+		"body": "lfoN_cutoff_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff_smoothccX",
+		"body": "lfoN_cutoff_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff_stepccX",
+		"body": "lfoN_cutoff_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff",
+		"body": "lfoN_cutoff=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff2_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff2_onccX",
+		"body": "lfoN_cutoff2_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff2_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff2_smoothccX",
+		"body": "lfoN_cutoff2_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff2_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff2_stepccX",
+		"body": "lfoN_cutoff2_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_cutoff2": {
+		"scope": "sfz",
+		"prefix": "lfoN_cutoff2",
+		"body": "lfoN_cutoff2=$0",
+		"description": "lfoN_cutoff alias. Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_delay_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_delay_onccX",
+		"body": "lfoN_delay_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_delay": {
+		"scope": "sfz",
+		"prefix": "lfoN_delay",
+		"body": "lfoN_delay=0$0",
+		"description": "Onset delay for LFO number N. Type: float | Range: N/A"
+	},
+	"SFZv2 lfoN_depth_lfoX": {
+		"scope": "sfz",
+		"prefix": "lfoN_depth_lfoX",
+		"body": "lfoN_depth_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_depthadd_lfoX": {
+		"scope": "sfz",
+		"prefix": "lfoN_depthadd_lfoX",
+		"body": "lfoN_depthadd_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXbw_onccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXbw_onccY",
+		"body": "lfoN_eqXbw_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXbw_smoothccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXbw_smoothccY",
+		"body": "lfoN_eqXbw_smoothccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXbw_stepccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXbw_stepccY",
+		"body": "lfoN_eqXbw_stepccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXbw": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXbw",
+		"body": "lfoN_eqXbw=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXfreq_onccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXfreq_onccY",
+		"body": "lfoN_eqXfreq_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXfreq_smoothccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXfreq_smoothccY",
+		"body": "lfoN_eqXfreq_smoothccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXfreq_stepccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXfreq_stepccY",
+		"body": "lfoN_eqXfreq_stepccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXfreq": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXfreq",
+		"body": "lfoN_eqXfreq=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXgain_onccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXgain_onccY",
+		"body": "lfoN_eqXgain_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXgain_smoothccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXgain_smoothccY",
+		"body": "lfoN_eqXgain_smoothccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXgain_stepccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXgain_stepccY",
+		"body": "lfoN_eqXgain_stepccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_eqXgain": {
+		"scope": "sfz",
+		"prefix": "lfoN_eqXgain",
+		"body": "lfoN_eqXgain=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_fade_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_fade_onccX",
+		"body": "lfoN_fade_onccX=$0",
+		"description": " Type: float | Range: N/A"
+	},
+	"SFZv2 lfoN_fade": {
+		"scope": "sfz",
+		"prefix": "lfoN_fade",
+		"body": "lfoN_fade=$0",
+		"description": "Fade-in time for LFO number N. Type: float | Range: N/A"
+	},
+	"SFZv2 lfoN_freq_lfoX": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq_lfoX",
+		"body": "lfoN_freq_lfoX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_freq_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq_onccX",
+		"body": "lfoN_freq_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_freq_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq_smoothccX",
+		"body": "lfoN_freq_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_freq_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq_stepccX",
+		"body": "lfoN_freq_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_freq": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq",
+		"body": "lfoN_freq=$0",
+		"description": "The base frequency of LFO number N, in Hertz. Type: float | Range: N/A"
+	},
+	"SFZv2 lfoN_pan_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pan_onccX",
+		"body": "lfoN_pan_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pan_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pan_smoothccX",
+		"body": "lfoN_pan_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pan_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pan_stepccX",
+		"body": "lfoN_pan_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pan": {
+		"scope": "sfz",
+		"prefix": "lfoN_pan",
+		"body": "lfoN_pan=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_phase_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_phase_onccX",
+		"body": "lfoN_phase_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_phase": {
+		"scope": "sfz",
+		"prefix": "lfoN_phase",
+		"body": "lfoN_phase=0$0",
+		"description": "Initial phase shift for LFO number N. Type: float | Range: 0 to 1"
+	},
+	"SFZv2 lfoN_pitch_curveccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pitch_curveccX",
+		"body": "lfoN_pitch_curveccX=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"SFZv2 lfoN_pitch_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pitch_onccX",
+		"body": "lfoN_pitch_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pitch_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pitch_smoothccX",
+		"body": "lfoN_pitch_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pitch_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_pitch_stepccX",
+		"body": "lfoN_pitch_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_pitch": {
+		"scope": "sfz",
+		"prefix": "lfoN_pitch",
+		"body": "lfoN_pitch=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance_onccX",
+		"body": "lfoN_resonance_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance_smoothccX",
+		"body": "lfoN_resonance_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance_stepccX",
+		"body": "lfoN_resonance_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance",
+		"body": "lfoN_resonance=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance2_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance2_onccX",
+		"body": "lfoN_resonance2_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance2_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance2_smoothccX",
+		"body": "lfoN_resonance2_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance2_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance2_stepccX",
+		"body": "lfoN_resonance2_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_resonance2": {
+		"scope": "sfz",
+		"prefix": "lfoN_resonance2",
+		"body": "lfoN_resonance2=$0",
+		"description": "lfoN_resonance alias. Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_smooth_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_smooth_onccX",
+		"body": "lfoN_smooth_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_smooth": {
+		"scope": "sfz",
+		"prefix": "lfoN_smooth",
+		"body": "lfoN_smooth=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_steps": {
+		"scope": "sfz",
+		"prefix": "lfoN_steps",
+		"body": "lfoN_steps=$0",
+		"description": "Number of steps in LFO step sequencer. Type: integer | Range: N/A"
+	},
+	"SFZv2 lfoN_stepX_onccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_stepX_onccY",
+		"body": "lfoN_stepX_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_stepX": {
+		"scope": "sfz",
+		"prefix": "lfoN_stepX",
+		"body": "lfoN_stepX=$0",
+		"description": "Level of the step number X in LFO step sequencer. Type: float | Range: -100 to 100 percent"
+	},
+	"SFZv2 lfoN_volume_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_volume_onccX",
+		"body": "lfoN_volume_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_volume_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_volume_smoothccX",
+		"body": "lfoN_volume_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_volume_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_volume_stepccX",
+		"body": "lfoN_volume_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_volume": {
+		"scope": "sfz",
+		"prefix": "lfoN_volume",
+		"body": "lfoN_volume=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_wave": {
+		"scope": "sfz",
+		"prefix": "lfoN_wave",
+		"body": "lfoN_wave=1$0",
+		"description": "LFO waveform selection. Type: integer | Range: N/A"
+	},
+	"SFZv2 lfoN_width_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_width_onccX",
+		"body": "lfoN_width_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_width_smoothccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_width_smoothccX",
+		"body": "lfoN_width_smoothccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_width_stepccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_width_stepccX",
+		"body": "lfoN_width_stepccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 lfoN_width": {
+		"scope": "sfz",
+		"prefix": "lfoN_width",
+		"body": "lfoN_width=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 loop_count": {
+		"scope": "sfz",
+		"prefix": "loop_count",
+		"body": "loop_count=$0",
+		"description": "The number of times a loop will repeat. Type: integer | Range: N/A"
+	},
+	"SFZv2 loop_crossfade": {
+		"scope": "sfz",
+		"prefix": "loop_crossfade",
+		"body": "loop_crossfade=$0",
+		"description": "Loop cross fade. Type: float | Range: N/A"
+	},
+	"SFZv2 loop_type": {
+		"scope": "sfz",
+		"prefix": "loop_type",
+		"body": "loop_type=forward$0",
+		"description": "Defines the looping mode. Type: string | Range: forward, backward, alternate"
+	},
+	"SFZv2 loprog": {
+		"scope": "sfz",
+		"prefix": "loprog",
+		"body": "loprog=0$0",
+		"description": "The region plays when the MIDI program number is between loprog and hiprog. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 lotimer": {
+		"scope": "sfz",
+		"prefix": "lotimer",
+		"body": "lotimer=$0",
+		"description": "Region plays if timer is between lotimer and hitimer. Type: float | Range: N/A"
+	},
+	"SFZv2 md5": {
+		"scope": "sfz",
+		"prefix": "md5",
+		"body": "md5=null$0",
+		"description": "Calculates the MD5 digital fingerprint hash of a sample file, represented as a sequence of 32 hexadecimal digits. Type: string | Range: N/A"
+	},
+	"SFZv2 note_offset": {
+		"scope": "sfz",
+		"prefix": "note_offset",
+		"body": "note_offset=$0",
+		"description": "Tells SFZ to shift all incoming MIDI data by the specified number of notes. Type: integer | Range: N/A"
+	},
+	"SFZv2 note_polyphony": {
+		"scope": "sfz",
+		"prefix": "note_polyphony",
+		"body": "note_polyphony=$0",
+		"description": "Polyphony limit for playing the same note repeatedly. Type: integer | Range: N/A"
+	},
+	"SFZv2 note_selfmask": {
+		"scope": "sfz",
+		"prefix": "note_selfmask",
+		"body": "note_selfmask=on$0",
+		"description": "Controls note-stealing behavior for a single pitch, when using note_polyphony. Type: string | Range: on, off"
+	},
+	"SFZv2 octave_offset": {
+		"scope": "sfz",
+		"prefix": "octave_offset",
+		"body": "octave_offset=$0",
+		"description": "Shifts all incoming MIDI data by the specified octave. Type: integer | Range: N/A"
+	},
+	"SFZv2 offset_onccN": {
+		"scope": "sfz",
+		"prefix": "offset_onccN",
+		"body": "offset_oncc${1:N}=0$0",
+		"description": "offset_ccN alias. Type: integer | Range: 0 to 4294967296 sample units"
+	},
+	"SFZv2 pan_keycenter": {
+		"scope": "sfz",
+		"prefix": "pan_keycenter",
+		"body": "pan_keycenter=60$0",
+		"description": "Center key for pan keyboard tracking. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 pan_keytrack": {
+		"scope": "sfz",
+		"prefix": "pan_keytrack",
+		"body": "pan_keytrack=0$0",
+		"description": "The amount by which the panning of a note is shifted with each key. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv2 pan_veltrack": {
+		"scope": "sfz",
+		"prefix": "pan_veltrack",
+		"body": "pan_veltrack=0$0",
+		"description": "The effect of note velocity on panning. Type: float | Range: -100 to 100 %"
+	},
+	"SFZv2 phase": {
+		"scope": "sfz",
+		"prefix": "phase",
+		"body": "phase=normal$0",
+		"description": "If invert is set, the region is played with inverted phase. Type: string | Range: normal, invert"
+	},
+	"SFZv2 pitch_curveccN": {
+		"scope": "sfz",
+		"prefix": "pitch_curveccN",
+		"body": "pitch_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"SFZv2 pitch_onccN": {
+		"scope": "sfz",
+		"prefix": "pitch_onccN",
+		"body": "pitch_oncc${1:N}=$0",
+		"description": " Type:  | Range: -9600 to 9600 cents"
+	},
+	"SFZv2 pitch_smoothccN": {
+		"scope": "sfz",
+		"prefix": "pitch_smoothccN",
+		"body": "pitch_smoothcc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to  ms"
+	},
+	"SFZv2 pitch_stepccN": {
+		"scope": "sfz",
+		"prefix": "pitch_stepccN",
+		"body": "pitch_stepcc${1:N}=0$0",
+		"description": " Type:  | Range: 0 to"
+	},
+	"SFZv2 pitchlfo_depth_onccN": {
+		"scope": "sfz",
+		"prefix": "pitchlfo_depth_onccN",
+		"body": "pitchlfo_depth_oncc${1:N}=0$0",
+		"description": "pitchlfo_depthccN alias. Type: float | Range: -1200 to 1200 cents"
+	},
+	"SFZv2 polyphony": {
+		"scope": "sfz",
+		"prefix": "polyphony",
+		"body": "polyphony=$0",
+		"description": "Polyphony voice limit. Type: integer | Range: N/A"
+	},
+	"SFZv2 resonance_ccN": {
+		"scope": "sfz",
+		"prefix": "resonance_ccN",
+		"body": "resonance_cc${1:N}=0$0",
+		"description": "resonance_onccN alias. Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv2 resonance_curveccN": {
+		"scope": "sfz",
+		"prefix": "resonance_curveccN",
+		"body": "resonance_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"SFZv2 resonance_onccN": {
+		"scope": "sfz",
+		"prefix": "resonance_onccN",
+		"body": "resonance_oncc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv2 resonance_smoothccN": {
+		"scope": "sfz",
+		"prefix": "resonance_smoothccN",
+		"body": "resonance_smoothcc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to  ms"
+	},
+	"SFZv2 resonance_stepccN": {
+		"scope": "sfz",
+		"prefix": "resonance_stepccN",
+		"body": "resonance_stepcc${1:N}=0$0",
+		"description": " Type: integer | Range: 0 to"
+	},
+	"SFZv2 resonance2_ccN": {
+		"scope": "sfz",
+		"prefix": "resonance2_ccN",
+		"body": "resonance2_cc${1:N}=0$0",
+		"description": "resonance2_onccN alias. Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv2 resonance2_curveccN": {
+		"scope": "sfz",
+		"prefix": "resonance2_curveccN",
+		"body": "resonance2_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"SFZv2 resonance2_onccN": {
+		"scope": "sfz",
+		"prefix": "resonance2_onccN",
+		"body": "resonance2_oncc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv2 resonance2_smoothccN": {
+		"scope": "sfz",
+		"prefix": "resonance2_smoothccN",
+		"body": "resonance2_smoothcc${1:N}=0$0",
+		"description": " Type: float | Range: 0 to  ms"
+	},
+	"SFZv2 resonance2_stepccN": {
+		"scope": "sfz",
+		"prefix": "resonance2_stepccN",
+		"body": "resonance2_stepcc${1:N}=0$0",
+		"description": " Type: integer | Range: 0 to"
+	},
+	"SFZv2 resonance2": {
+		"scope": "sfz",
+		"prefix": "resonance2",
+		"body": "resonance2=0$0",
+		"description": "resonance alias. Type: float | Range: 0 to 40 dB"
+	},
+	"SFZv2 reverse_hiccN": {
+		"scope": "sfz",
+		"prefix": "reverse_hiccN",
+		"body": "reverse_hicc${1:N}=$0",
+		"description": "If MIDI CC N is between reverse_loccN and reverse_hiccN, the region plays reversed. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 reverse_loccN": {
+		"scope": "sfz",
+		"prefix": "reverse_loccN",
+		"body": "reverse_locc${1:N}=$0",
+		"description": "If MIDI CC N is between reverse_loccN and reverse_hiccN, the region plays reversed. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 rt_dead": {
+		"scope": "sfz",
+		"prefix": "rt_dead",
+		"body": "rt_dead=off$0",
+		"description": "Controls whether a release sample should play if its sustain sample has ended, or not. Type: string | Range: on, off"
+	},
+	"SFZv2 set_ccN": {
+		"scope": "sfz",
+		"prefix": "set_ccN",
+		"body": "set_cc${1:N}=$0",
+		"description": "Sets a default initial value for MIDI CC number N, when the instrument is initially loaded. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 sostenuto_sw": {
+		"scope": "sfz",
+		"prefix": "sostenuto_sw",
+		"body": "sostenuto_sw=$0",
+		"description": "Turns the sostenuto switch on or off. Type: string | Range: on, off"
+	},
+	"SFZv2 start_hiccN": {
+		"scope": "sfz",
+		"prefix": "start_hiccN",
+		"body": "start_hicc${1:N}=-1$0",
+		"description": "on_hiccN alias. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 start_loccN": {
+		"scope": "sfz",
+		"prefix": "start_loccN",
+		"body": "start_locc${1:N}=-1$0",
+		"description": "on_loccN alias. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 stop_beats": {
+		"scope": "sfz",
+		"prefix": "stop_beats",
+		"body": "stop_beats=$0",
+		"description": "Stops a region after a certain amount of beats have played. Type: float | Range: N/A"
+	},
+	"SFZv2 stop_hiccN": {
+		"scope": "sfz",
+		"prefix": "stop_hiccN",
+		"body": "stop_hicc${1:N}=-1$0",
+		"description": "If a MIDI control message with a value between stop_loccN and stop_hiccN is received, the region will stop playing. Default value is -1, it means unassigned. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 stop_loccN": {
+		"scope": "sfz",
+		"prefix": "stop_loccN",
+		"body": "stop_locc${1:N}=-1$0",
+		"description": "If a MIDI control message with a value between stop_loccN and stop_hiccN is received, the region will stop playing. Default value is -1, it means unassigned. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 sustain_sw": {
+		"scope": "sfz",
+		"prefix": "sustain_sw",
+		"body": "sustain_sw=$0",
+		"description": "Turns the sustain switch on or off. Type: string | Range: on, off"
+	},
+	"SFZv2 sw_default": {
+		"scope": "sfz",
+		"prefix": "sw_default",
+		"body": "sw_default=$0",
+		"description": "Define keyswitch 'power on default' so that you hear something when a patch loads. Type: integer | Range: 0 to 127"
+	},
+	"SFZv2 type": {
+		"scope": "sfz",
+		"prefix": "type",
+		"body": "type=$0",
+		"description": "Effect type or vendor-specific effect name. Varies across SFZ players. Type: string | Range: apan, comp, delay, disto, eq, filter, fverb, gate, limiter, lofi, mverb, phaser, static, strings, tdfir, com.mda.Limiter, com.mda.Overdrive, com.mda.Leslie, com.mda.RingMod, com.mda.Delay, com.mda.Bandisto, com.mda.Ambience, com.mda.DubDelay, com.mda.Detune, com.mda.Dither, com.mda.Combo, com.mda.Degrade, com.mda.SubSynth, com.mda.RezFilter"
+	},
+	"SFZv2 vN": {
+		"scope": "sfz",
+		"prefix": "vN",
+		"body": "vN=$0",
+		"description": " Type: float | Range: -1 to 1"
+	},
+	"SFZv2 volume_curveccN": {
+		"scope": "sfz",
+		"prefix": "volume_curveccN",
+		"body": "volume_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"SFZv2 volume_onccN": {
+		"scope": "sfz",
+		"prefix": "volume_onccN",
+		"body": "volume_oncc${1:N}=0$0",
+		"description": "gain_ccN alias. Type: float | Range: -144 to 48 dB"
+	},
+	"SFZv2 volume_smoothccN": {
+		"scope": "sfz",
+		"prefix": "volume_smoothccN",
+		"body": "volume_smoothcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 volume_stepccN": {
+		"scope": "sfz",
+		"prefix": "volume_stepccN",
+		"body": "volume_stepcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"SFZv2 waveguide": {
+		"scope": "sfz",
+		"prefix": "waveguide",
+		"body": "waveguide=$0",
+		"description": "Enables waveguide synthesis for the region. Type: string | Range: on, off"
+	},
+
+	"ARIA amp_veltrack_ccN": {
+		"scope": "sfz",
+		"prefix": "amp_veltrack_ccN",
+		"body": "amp_veltrack_cc${1:N}=$0",
+		"description": "amp_veltrack_onccN alias. Type:  | Range: N/A"
+	},
+	"ARIA amp_veltrack_curveccN": {
+		"scope": "sfz",
+		"prefix": "amp_veltrack_curveccN",
+		"body": "amp_veltrack_curvecc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA amp_veltrack_onccN": {
+		"scope": "sfz",
+		"prefix": "amp_veltrack_onccN",
+		"body": "amp_veltrack_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA amp_veltrack_random": {
+		"scope": "sfz",
+		"prefix": "amp_veltrack_random",
+		"body": "amp_veltrack_random=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA ampeg_attack_shape": {
+		"scope": "sfz",
+		"prefix": "ampeg_attack_shape",
+		"body": "ampeg_attack_shape=0$0",
+		"description": "Specifies the curvature of attack stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA ampeg_decay_curveccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_decay_curveccN",
+		"body": "ampeg_decay_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"ARIA ampeg_decay_shape": {
+		"scope": "sfz",
+		"prefix": "ampeg_decay_shape",
+		"body": "ampeg_decay_shape=-10.3616$0",
+		"description": "Specifies the curvature of decay stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA ampeg_decay_zero": {
+		"scope": "sfz",
+		"prefix": "ampeg_decay_zero",
+		"body": "ampeg_decay_zero=1$0",
+		"description": "Specifies how decay time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA ampeg_dynamic": {
+		"scope": "sfz",
+		"prefix": "ampeg_dynamic",
+		"body": "ampeg_dynamic=0$0",
+		"description": "Specifies when envelope durations are recalculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA ampeg_hold_curveccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_hold_curveccN",
+		"body": "ampeg_hold_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"ARIA ampeg_release_shape": {
+		"scope": "sfz",
+		"prefix": "ampeg_release_shape",
+		"body": "ampeg_release_shape=-10.3616$0",
+		"description": "Specifies the curvature of release stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA ampeg_release_zero": {
+		"scope": "sfz",
+		"prefix": "ampeg_release_zero",
+		"body": "ampeg_release_zero=0$0",
+		"description": "Specifies how release time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA ampeg_sustain_curveccN": {
+		"scope": "sfz",
+		"prefix": "ampeg_sustain_curveccN",
+		"body": "ampeg_sustain_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"ARIA amplitude_ccN": {
+		"scope": "sfz",
+		"prefix": "amplitude_ccN",
+		"body": "amplitude_cc${1:N}=$0",
+		"description": "amplitude_onccN alias. Type: float | Range: 0 to 100 %"
+	},
+	"ARIA amplitude_curveccN": {
+		"scope": "sfz",
+		"prefix": "amplitude_curveccN",
+		"body": "amplitude_curvecc${1:N}=$0",
+		"description": " Type: integer | Range: 0 to 255"
+	},
+	"ARIA amplitude_onccN": {
+		"scope": "sfz",
+		"prefix": "amplitude_onccN",
+		"body": "amplitude_oncc${1:N}=$0",
+		"description": " Type: float | Range: 0 to 100 %"
+	},
+	"ARIA amplitude_smoothccN": {
+		"scope": "sfz",
+		"prefix": "amplitude_smoothccN",
+		"body": "amplitude_smoothcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA amplitude": {
+		"scope": "sfz",
+		"prefix": "amplitude",
+		"body": "amplitude=100$0",
+		"description": "Amplitude for the specified region in percentage of full amplitude. Type: float | Range: 0 to 100 %"
+	},
+	"ARIA curve_index": {
+		"scope": "sfz",
+		"prefix": "curve_index",
+		"body": "curve_index=$0",
+		"description": "Curve ID definition. Type: integer | Range: 0 to 255"
+	},
+	"ARIA cutoff2_random": {
+		"scope": "sfz",
+		"prefix": "cutoff2_random",
+		"body": "cutoff2_random=0$0",
+		"description": "fil_random alias. Type: integer | Range: 0 to 9600 cents"
+	},
+	"ARIA delay_beats_curveccN": {
+		"scope": "sfz",
+		"prefix": "delay_beats_curveccN",
+		"body": "delay_beats_curvecc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA delay_beats_onccN": {
+		"scope": "sfz",
+		"prefix": "delay_beats_onccN",
+		"body": "delay_beats_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA delay_beats_random": {
+		"scope": "sfz",
+		"prefix": "delay_beats_random",
+		"body": "delay_beats_random=$0",
+		"description": "Delays the start of the region after a random amount of musical beats. Type: float | Range: N/A"
+	},
+	"ARIA delay_curveccN": {
+		"scope": "sfz",
+		"prefix": "delay_curveccN",
+		"body": "delay_curvecc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA egN_ampeg": {
+		"scope": "sfz",
+		"prefix": "egN_ampeg",
+		"body": "egN_ampeg=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA eqN_dynamic": {
+		"scope": "sfz",
+		"prefix": "eqN_dynamic",
+		"body": "eqN_dynamic=0$0",
+		"description": "Specifies when EQ is recalculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA fil_gain_onccN": {
+		"scope": "sfz",
+		"prefix": "fil_gain_onccN",
+		"body": "fil_gain_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA fil_gain": {
+		"scope": "sfz",
+		"prefix": "fil_gain",
+		"body": "fil_gain=0$0",
+		"description": "Gain for lsh, hsh and peq filter types. Type: float | Range: N/A"
+	},
+	"ARIA fil2_gain_onccN": {
+		"scope": "sfz",
+		"prefix": "fil2_gain_onccN",
+		"body": "fil2_gain_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA fil2_gain": {
+		"scope": "sfz",
+		"prefix": "fil2_gain",
+		"body": "fil2_gain=0$0",
+		"description": "fil_gain alias. Type: float | Range: N/A"
+	},
+	"ARIA fileg_attack_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_attack_onccN",
+		"body": "fileg_attack_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_attack_shape": {
+		"scope": "sfz",
+		"prefix": "fileg_attack_shape",
+		"body": "fileg_attack_shape=0$0",
+		"description": "Specifies the curvature of attack stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA fileg_attackccN": {
+		"scope": "sfz",
+		"prefix": "fileg_attackccN",
+		"body": "fileg_attackcc${1:N}=0$0",
+		"description": "fileg_attack_onccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_decay_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_decay_onccN",
+		"body": "fileg_decay_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_decay_shape": {
+		"scope": "sfz",
+		"prefix": "fileg_decay_shape",
+		"body": "fileg_decay_shape=0$0",
+		"description": "Specifies the curvature of decay stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA fileg_decay_zero": {
+		"scope": "sfz",
+		"prefix": "fileg_decay_zero",
+		"body": "fileg_decay_zero=1$0",
+		"description": "Specifies how decay time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA fileg_decayccN": {
+		"scope": "sfz",
+		"prefix": "fileg_decayccN",
+		"body": "fileg_decaycc${1:N}=0$0",
+		"description": "fileg_decay_onccN alias. Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_delay_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_delay_onccN",
+		"body": "fileg_delay_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_delayccN": {
+		"scope": "sfz",
+		"prefix": "fileg_delayccN",
+		"body": "fileg_delaycc${1:N}=0$0",
+		"description": "fileg_delay_onccN alias. Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_depth_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_depth_onccN",
+		"body": "fileg_depth_oncc${1:N}=0$0",
+		"description": " Type: integer | Range: -12000 to 12000 cents"
+	},
+	"ARIA fileg_depthccN": {
+		"scope": "sfz",
+		"prefix": "fileg_depthccN",
+		"body": "fileg_depthcc${1:N}=0$0",
+		"description": "fileg_depth_onccN alias. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"ARIA fileg_dynamic": {
+		"scope": "sfz",
+		"prefix": "fileg_dynamic",
+		"body": "fileg_dynamic=0$0",
+		"description": "Specifies when envelope durations are recalculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA fileg_hold_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_hold_onccN",
+		"body": "fileg_hold_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_holdccN": {
+		"scope": "sfz",
+		"prefix": "fileg_holdccN",
+		"body": "fileg_holdcc${1:N}=0$0",
+		"description": "fileg_hold_onccN alias. Type: float | Range: -100 to 100"
+	},
+	"ARIA fileg_release_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_release_onccN",
+		"body": "fileg_release_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_release_shape": {
+		"scope": "sfz",
+		"prefix": "fileg_release_shape",
+		"body": "fileg_release_shape=0$0",
+		"description": "Specifies the curvature of release stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA fileg_release_zero": {
+		"scope": "sfz",
+		"prefix": "fileg_release_zero",
+		"body": "fileg_release_zero=0$0",
+		"description": "Specifies how release time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA fileg_releaseccN": {
+		"scope": "sfz",
+		"prefix": "fileg_releaseccN",
+		"body": "fileg_releasecc${1:N}=0$0",
+		"description": "fileg_release_onccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_start_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_start_onccN",
+		"body": "fileg_start_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_startccN": {
+		"scope": "sfz",
+		"prefix": "fileg_startccN",
+		"body": "fileg_startcc${1:N}=0$0",
+		"description": "fileg_start_onccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_sustain_onccN": {
+		"scope": "sfz",
+		"prefix": "fileg_sustain_onccN",
+		"body": "fileg_sustain_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA fileg_sustainccN": {
+		"scope": "sfz",
+		"prefix": "fileg_sustainccN",
+		"body": "fileg_sustaincc${1:N}=0$0",
+		"description": "fileg_sustain_onccN alias. Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA global_amplitude": {
+		"scope": "sfz",
+		"prefix": "global_amplitude",
+		"body": "global_amplitude=100$0",
+		"description": "ARIA extension, like amplitude, but affecting everything when set under the ‹global› header. Type: float | Range: 0 to 100 %"
+	},
+	"ARIA global_label": {
+		"scope": "sfz",
+		"prefix": "global_label",
+		"body": "global_label=null$0",
+		"description": "An ARIA extension which sets what is displayed in the default info tab of Sforzando. Type: string | Range: N/A"
+	},
+	"ARIA global_tune": {
+		"scope": "sfz",
+		"prefix": "global_tune",
+		"body": "global_tune=0$0",
+		"description": "ARIA extension, like tune, but affecting everything when set under the ‹global› header. Type: integer | Range: -100 to 100 cents"
+	},
+	"ARIA global_volume": {
+		"scope": "sfz",
+		"prefix": "global_volume",
+		"body": "global_volume=0$0",
+		"description": "ARIA extension, like volume, but affecting everything when set under the ‹global› header. Type: float | Range: -144 to 6 dB"
+	},
+	"ARIA group_amplitude": {
+		"scope": "sfz",
+		"prefix": "group_amplitude",
+		"body": "group_amplitude=100$0",
+		"description": "ARIA extension, like amplitude, but affecting everything when set under the ‹group› header. Type: float | Range: 0 to 100 %"
+	},
+	"ARIA group_label": {
+		"scope": "sfz",
+		"prefix": "group_label",
+		"body": "group_label=null$0",
+		"description": "An ARIA extension which sets what is displayed in the default info tab of Sforzando. Type: string | Range: N/A"
+	},
+	"ARIA group_tune": {
+		"scope": "sfz",
+		"prefix": "group_tune",
+		"body": "group_tune=0$0",
+		"description": "ARIA extension, like tune, but affecting everything when set under the ‹group› header. Type: integer | Range: -100 to 100 cents"
+	},
+	"ARIA group_volume": {
+		"scope": "sfz",
+		"prefix": "group_volume",
+		"body": "group_volume=0$0",
+		"description": "ARIA extension, like volume, but affecting everything when set under the ‹group› header. Type: float | Range: -144 to 6 dB"
+	},
+	"ARIA hihdccN": {
+		"scope": "sfz",
+		"prefix": "hihdccN",
+		"body": "hihdcc${1:N}=1$0",
+		"description": "Like hiccN but with floating point MIDI CCs Type: float | Range: 0 to 1"
+	},
+	"ARIA hint_*": {
+		"scope": "sfz",
+		"prefix": "hint_*",
+		"body": "hint_*=$0",
+		"description": "Its a 'hint' to the ARIA engine, others implementations don't have to follow. Type:  | Range: N/A"
+	},
+	"ARIA #include": {
+		"scope": "sfz",
+		"prefix": "#include",
+		"body": "#include=$0",
+		"description": "A special directive, which allows using SFZ files as building blocks for creating larger, more complex SFZ files. Type: string | Range: N/A"
+	},
+	"ARIA label_ccN": {
+		"scope": "sfz",
+		"prefix": "label_ccN",
+		"body": "label_cc${1:N}=$0",
+		"description": "Creates a label for the MIDI CC. Type: string | Range: N/A"
+	},
+	"ARIA lfoN_freq_lfoX_onccY": {
+		"scope": "sfz",
+		"prefix": "lfoN_freq_lfoX_onccY",
+		"body": "lfoN_freq_lfoX_onccY=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA lfoN_offset": {
+		"scope": "sfz",
+		"prefix": "lfoN_offset",
+		"body": "lfoN_offset=$0",
+		"description": "DC offset - Add to LFO output; not affected by scale. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_offsetX": {
+		"scope": "sfz",
+		"prefix": "lfoN_offsetX",
+		"body": "lfoN_offsetX=$0",
+		"description": "lfoN_offset alias. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_ratio": {
+		"scope": "sfz",
+		"prefix": "lfoN_ratio",
+		"body": "lfoN_ratio=$0",
+		"description": "Sets the ratio between the specified sub waveform and the main waveform. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_ratioX": {
+		"scope": "sfz",
+		"prefix": "lfoN_ratioX",
+		"body": "lfoN_ratioX=$0",
+		"description": "lfoN_ratio alias. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_scale": {
+		"scope": "sfz",
+		"prefix": "lfoN_scale",
+		"body": "lfoN_scale=$0",
+		"description": "Sets the scaling between the specified sub waveform and the main waveform. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_scaleX": {
+		"scope": "sfz",
+		"prefix": "lfoN_scaleX",
+		"body": "lfoN_scaleX=$0",
+		"description": "lfoN_scale alias. Type: float | Range: N/A"
+	},
+	"ARIA lfoN_wave_onccX": {
+		"scope": "sfz",
+		"prefix": "lfoN_wave_onccX",
+		"body": "lfoN_wave_onccX=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA lfoN_waveX": {
+		"scope": "sfz",
+		"prefix": "lfoN_waveX",
+		"body": "lfoN_waveX=1$0",
+		"description": "lfoN_wave alias. Type: integer | Range: N/A"
+	},
+	"ARIA lohdccN": {
+		"scope": "sfz",
+		"prefix": "lohdccN",
+		"body": "lohdcc${1:N}=0$0",
+		"description": "Like loccN but with floating point MIDI CCs Type: float | Range: 0 to 1"
+	},
+	"ARIA loopcount": {
+		"scope": "sfz",
+		"prefix": "loopcount",
+		"body": "loopcount=$0",
+		"description": "loop_count alias. Type: integer | Range: N/A"
+	},
+	"ARIA looptune": {
+		"scope": "sfz",
+		"prefix": "looptune",
+		"body": "looptune=0$0",
+		"description": "loop_tune alias. Type: float | Range: N/A"
+	},
+	"ARIA looptype": {
+		"scope": "sfz",
+		"prefix": "looptype",
+		"body": "looptype=forward$0",
+		"description": "loop_type alias. Type: string | Range: forward, backward, alternate"
+	},
+	"ARIA master_amplitude": {
+		"scope": "sfz",
+		"prefix": "master_amplitude",
+		"body": "master_amplitude=100$0",
+		"description": "ARIA extension, like amplitude, but affecting everything when set under the ‹master› header. Type: float | Range: 0 to 100 %"
+	},
+	"ARIA master_label": {
+		"scope": "sfz",
+		"prefix": "master_label",
+		"body": "master_label=null$0",
+		"description": "An ARIA extension which sets what is displayed in the default info tab of Sforzando. Type: string | Range: N/A"
+	},
+	"ARIA master_tune": {
+		"scope": "sfz",
+		"prefix": "master_tune",
+		"body": "master_tune=0$0",
+		"description": "ARIA extension, like tune, but affecting everything when set under the ‹master› header. Type: integer | Range: -100 to 100 cents"
+	},
+	"ARIA master_volume": {
+		"scope": "sfz",
+		"prefix": "master_volume",
+		"body": "master_volume=0$0",
+		"description": "ARIA extension, like volume, but affecting everything when set under the ‹master› header. Type: float | Range: -144 to 6 dB"
+	},
+	"ARIA off_curve": {
+		"scope": "sfz",
+		"prefix": "off_curve",
+		"body": "off_curve=10$0",
+		"description": "When off_mode is set to time, this specifies the math to be used to fade out the regions being muted by voice-stealing. Type: integer | Range: -2 to 10"
+	},
+	"ARIA off_shape": {
+		"scope": "sfz",
+		"prefix": "off_shape",
+		"body": "off_shape=-10.3616$0",
+		"description": "The coefficient used by off_curve. Type: float | Range: N/A"
+	},
+	"ARIA off_time": {
+		"scope": "sfz",
+		"prefix": "off_time",
+		"body": "off_time=0.006$0",
+		"description": "When off_mode is set to time, this specifies the fadeout time for regions being muted by voice-stealing. Type: float | Range: N/A"
+	},
+	"ARIA on_hihdccN": {
+		"scope": "sfz",
+		"prefix": "on_hihdccN",
+		"body": "on_hihdcc${1:N}=-1$0",
+		"description": "Like on_hiccN but with floating point MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA on_lohdccN": {
+		"scope": "sfz",
+		"prefix": "on_lohdccN",
+		"body": "on_lohdcc${1:N}=-1$0",
+		"description": "Like on_loccN but with floating point MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA pan_ccN": {
+		"scope": "sfz",
+		"prefix": "pan_ccN",
+		"body": "pan_cc${1:N}=$0",
+		"description": "pan_onccN alias. Type:  | Range: N/A"
+	},
+	"ARIA pan_law": {
+		"scope": "sfz",
+		"prefix": "pan_law",
+		"body": "pan_law=$0",
+		"description": "Sets the pan law to be used. Type: string | Range: mma, balance"
+	},
+	"ARIA pan_random": {
+		"scope": "sfz",
+		"prefix": "pan_random",
+		"body": "pan_random=0$0",
+		"description": "Random panoramic position for the region. Type: float | Range: -100 to 100 %"
+	},
+	"ARIA param_offset": {
+		"scope": "sfz",
+		"prefix": "param_offset",
+		"body": "param_offset=$0",
+		"description": "Adds a number to the parameter numbers of built-in or vendor-specific effects. Type: integer | Range: N/A"
+	},
+	"ARIA pitch": {
+		"scope": "sfz",
+		"prefix": "pitch",
+		"body": "pitch=0$0",
+		"description": "tune alias. Type: integer | Range: -100 to 100 cents"
+	},
+	"ARIA pitcheg_attack_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_attack_onccN",
+		"body": "pitcheg_attack_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA pitcheg_attack_shape": {
+		"scope": "sfz",
+		"prefix": "pitcheg_attack_shape",
+		"body": "pitcheg_attack_shape=0$0",
+		"description": "Specifies the curvature of attack stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA pitcheg_decay_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_decay_onccN",
+		"body": "pitcheg_decay_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA pitcheg_decay_shape": {
+		"scope": "sfz",
+		"prefix": "pitcheg_decay_shape",
+		"body": "pitcheg_decay_shape=0$0",
+		"description": "Specifies the curvature of decay stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA pitcheg_decay_zero": {
+		"scope": "sfz",
+		"prefix": "pitcheg_decay_zero",
+		"body": "pitcheg_decay_zero=1$0",
+		"description": "Specifies how decay time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA pitcheg_delay_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_delay_onccN",
+		"body": "pitcheg_delay_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA pitcheg_depth_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_depth_onccN",
+		"body": "pitcheg_depth_oncc${1:N}=0$0",
+		"description": " Type: integer | Range: -12000 to 12000 cents"
+	},
+	"ARIA pitcheg_depthccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_depthccN",
+		"body": "pitcheg_depthcc${1:N}=0$0",
+		"description": "pitcheg_depth_onccN alias. Type: integer | Range: -12000 to 12000 cents"
+	},
+	"ARIA pitcheg_dynamic": {
+		"scope": "sfz",
+		"prefix": "pitcheg_dynamic",
+		"body": "pitcheg_dynamic=0$0",
+		"description": "Specifies when envelope durations are recalculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA pitcheg_hold_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_hold_onccN",
+		"body": "pitcheg_hold_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100"
+	},
+	"ARIA pitcheg_release_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_release_onccN",
+		"body": "pitcheg_release_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA pitcheg_release_shape": {
+		"scope": "sfz",
+		"prefix": "pitcheg_release_shape",
+		"body": "pitcheg_release_shape=0$0",
+		"description": "Specifies the curvature of release stage of the envelope. Type: float | Range: N/A"
+	},
+	"ARIA pitcheg_release_zero": {
+		"scope": "sfz",
+		"prefix": "pitcheg_release_zero",
+		"body": "pitcheg_release_zero=0$0",
+		"description": "Specifies how release time is calculated. Type: integer | Range: 0 to 1"
+	},
+	"ARIA pitcheg_start_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_start_onccN",
+		"body": "pitcheg_start_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA pitcheg_sustain_onccN": {
+		"scope": "sfz",
+		"prefix": "pitcheg_sustain_onccN",
+		"body": "pitcheg_sustain_oncc${1:N}=0$0",
+		"description": " Type: float | Range: -100 to 100 seconds"
+	},
+	"ARIA polyphony_group": {
+		"scope": "sfz",
+		"prefix": "polyphony_group",
+		"body": "polyphony_group=0$0",
+		"description": "group alias. Type: integer | Range: -2147483648 to 2147483647"
+	},
+	"ARIA polyphony_stealing": {
+		"scope": "sfz",
+		"prefix": "polyphony_stealing",
+		"body": "polyphony_stealing=$0",
+		"description": " Type: integer | Range: N/A"
+	},
+	"ARIA position_curveccN": {
+		"scope": "sfz",
+		"prefix": "position_curveccN",
+		"body": "position_curvecc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_keycenter": {
+		"scope": "sfz",
+		"prefix": "position_keycenter",
+		"body": "position_keycenter=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_keytrack": {
+		"scope": "sfz",
+		"prefix": "position_keytrack",
+		"body": "position_keytrack=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_onccN": {
+		"scope": "sfz",
+		"prefix": "position_onccN",
+		"body": "position_oncc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_random": {
+		"scope": "sfz",
+		"prefix": "position_random",
+		"body": "position_random=0$0",
+		"description": " Type: float | Range: -100 to 100 %"
+	},
+	"ARIA position_smoothccN": {
+		"scope": "sfz",
+		"prefix": "position_smoothccN",
+		"body": "position_smoothcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_stepccN": {
+		"scope": "sfz",
+		"prefix": "position_stepccN",
+		"body": "position_stepcc${1:N}=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA position_veltrack": {
+		"scope": "sfz",
+		"prefix": "position_veltrack",
+		"body": "position_veltrack=$0",
+		"description": " Type:  | Range: N/A"
+	},
+	"ARIA region_label": {
+		"scope": "sfz",
+		"prefix": "region_label",
+		"body": "region_label=null$0",
+		"description": "An ARIA extension which sets what is displayed in the default info tab of Sforzando. Type: string | Range: N/A"
+	},
+	"ARIA resonance_random": {
+		"scope": "sfz",
+		"prefix": "resonance_random",
+		"body": "resonance_random=0$0",
+		"description": "Filter cutoff resonance random value, in decibels. Type: float | Range: 0 to 40 dB"
+	},
+	"ARIA set_hdccN": {
+		"scope": "sfz",
+		"prefix": "set_hdccN",
+		"body": "set_hdcc${1:N}=$0",
+		"description": "Like set_ccN but with floating point MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA set_realccN": {
+		"scope": "sfz",
+		"prefix": "set_realccN",
+		"body": "set_realcc${1:N}=$0",
+		"description": "set_hdccN alias. Type: float | Range: 0 to 1"
+	},
+	"ARIA sostenuto_cc": {
+		"scope": "sfz",
+		"prefix": "sostenuto_cc",
+		"body": "sostenuto_cc=66$0",
+		"description": "Reassigns the sostenuto pedal CC to a non-standard value. Type: float | Range: 0 to 127"
+	},
+	"ARIA sostenuto_lo": {
+		"scope": "sfz",
+		"prefix": "sostenuto_lo",
+		"body": "sostenuto_lo=0.5$0",
+		"description": "Sets the minimum point at which the sostenuto pedal (MIDI CC 66) is considered 'down'. Type: float | Range: 0 to 127"
+	},
+	"ARIA start_hihdccN": {
+		"scope": "sfz",
+		"prefix": "start_hihdccN",
+		"body": "start_hihdcc${1:N}=-1$0",
+		"description": "on_hihdccN alias. Type: float | Range: 0 to 1"
+	},
+	"ARIA start_lohdccN": {
+		"scope": "sfz",
+		"prefix": "start_lohdccN",
+		"body": "start_lohdcc${1:N}=-1$0",
+		"description": "on_lohdccN alias. Type: float | Range: 0 to 1"
+	},
+	"ARIA stop_hihdccN": {
+		"scope": "sfz",
+		"prefix": "stop_hihdccN",
+		"body": "stop_hihdcc${1:N}=-1$0",
+		"description": "Like stop_hiccN but with floating point MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA stop_lohdccN": {
+		"scope": "sfz",
+		"prefix": "stop_lohdccN",
+		"body": "stop_lohdcc${1:N}=-1$0",
+		"description": "Like stop_loccN but with floating point MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA sustain_cc": {
+		"scope": "sfz",
+		"prefix": "sustain_cc",
+		"body": "sustain_cc=64$0",
+		"description": "Reassigns the sustain pedal CC to a non-standard value. Type: float | Range: 0 to 127"
+	},
+	"ARIA sustain_lo": {
+		"scope": "sfz",
+		"prefix": "sustain_lo",
+		"body": "sustain_lo=0.5$0",
+		"description": "Sets the minimum point at which the sustain pedal (MIDI CC 64) is considered 'down'. Type: float | Range: 0 to 127"
+	},
+	"ARIA sw_hilast": {
+		"scope": "sfz",
+		"prefix": "sw_hilast",
+		"body": "sw_hilast=$0",
+		"description": "Like sw_last, but allowing a region to be triggered across a range of keyswitches. Type: integer | Range: 0 to 127"
+	},
+	"ARIA sw_label": {
+		"scope": "sfz",
+		"prefix": "sw_label",
+		"body": "sw_label=$0",
+		"description": "Label for activated keyswitch on GUI. Type: string | Range: N/A"
+	},
+	"ARIA sw_lolast": {
+		"scope": "sfz",
+		"prefix": "sw_lolast",
+		"body": "sw_lolast=$0",
+		"description": "Like sw_last, but allowing a region to be triggered across a range of keyswitches. Type: integer | Range: 0 to 127"
+	},
+	"ARIA sw_note_offset": {
+		"scope": "sfz",
+		"prefix": "sw_note_offset",
+		"body": "sw_note_offset=$0",
+		"description": "Follows the same logic as SFZ 2.0’s note_offset but for key switches. Type: integer | Range: N/A"
+	},
+	"ARIA sw_octave_offset": {
+		"scope": "sfz",
+		"prefix": "sw_octave_offset",
+		"body": "sw_octave_offset=$0",
+		"description": "Follows the same logic as SFZ 2.0’s octave_offset but for key switches. Type: integer | Range: N/A"
+	},
+	"ARIA tune_ccN": {
+		"scope": "sfz",
+		"prefix": "tune_ccN",
+		"body": "tune_cc${1:N}=$0",
+		"description": "pitch_onccN alias. Type:  | Range: -9600 to 9600 cents"
+	},
+	"ARIA tune_curveccN": {
+		"scope": "sfz",
+		"prefix": "tune_curveccN",
+		"body": "tune_curvecc${1:N}=$0",
+		"description": "pitch_curveccN alias. Type: integer | Range: 0 to 255"
+	},
+	"ARIA tune_keytrack": {
+		"scope": "sfz",
+		"prefix": "tune_keytrack",
+		"body": "tune_keytrack=100$0",
+		"description": "pitch_keytrack alias. Type: integer | Range: -1200 to 1200"
+	},
+	"ARIA tune_onccN": {
+		"scope": "sfz",
+		"prefix": "tune_onccN",
+		"body": "tune_oncc${1:N}=$0",
+		"description": "pitch_onccN alias. Type:  | Range: -9600 to 9600 cents"
+	},
+	"ARIA tune_random": {
+		"scope": "sfz",
+		"prefix": "tune_random",
+		"body": "tune_random=0$0",
+		"description": "pitch_random alias. Type: integer | Range: 0 to 9600 cents"
+	},
+	"ARIA tune_smoothccN": {
+		"scope": "sfz",
+		"prefix": "tune_smoothccN",
+		"body": "tune_smoothcc${1:N}=0$0",
+		"description": "pitch_smoothccN alias. Type: float | Range: 0 to  ms"
+	},
+	"ARIA tune_stepccN": {
+		"scope": "sfz",
+		"prefix": "tune_stepccN",
+		"body": "tune_stepcc${1:N}=0$0",
+		"description": "pitch_stepccN alias. Type:  | Range: 0 to"
+	},
+	"ARIA tune_veltrack": {
+		"scope": "sfz",
+		"prefix": "tune_veltrack",
+		"body": "tune_veltrack=0$0",
+		"description": "pitch_veltrack alias. Type: integer | Range: -9600 to 9600 cents"
+	},
+	"ARIA varNN_*": {
+		"scope": "sfz",
+		"prefix": "varNN_*",
+		"body": "varNN_*=$0",
+		"description": "Specifies the target for variable NN to modulate. Type:  | Range: N/A"
+	},
+	"ARIA varNN_curveccX": {
+		"scope": "sfz",
+		"prefix": "varNN_curveccX",
+		"body": "varNN_curveccX=$0",
+		"description": "Specifies the ‹curve› number which MIDI CC X uses to modulate variable NN. Type: integer | Range: 0 to 255"
+	},
+	"ARIA varNN_mod": {
+		"scope": "sfz",
+		"prefix": "varNN_mod",
+		"body": "varNN_mod=$0",
+		"description": "Specifies the method used to calculate variable number NN from MIDI CCs. Type: string | Range: mult, add"
+	},
+	"ARIA varNN_onccX": {
+		"scope": "sfz",
+		"prefix": "varNN_onccX",
+		"body": "varNN_onccX=$0",
+		"description": "Specifies the method used to calculate variable number NN from MIDI CCs. Type: float | Range: 0 to 1"
+	},
+	"ARIA vendor_specific": {
+		"scope": "sfz",
+		"prefix": "vendor_specific",
+		"body": "vendor_specific=$0",
+		"description": "Defines vendor-specific effects, for example Garritan-specific stage depth effect in ARIA. Type: string | Range: N/A"
+	},
+
+	"MIDI CC0": {
+		"scope": "sfz",
+		"prefix": "cc000: Bank Select",
+		"body": "cc0=$0",
+		"description": "MIDI CC for bank select. Used to switch preset banks for patch selection in conjunction with program change commands."
+	},
+	"MIDI CC1": {
+		"scope": "sfz",
+		"prefix": "cc001: Modulation Wheel",
+		"body": "cc1=$0",
+		"description": "MIDI CC for modulation wheel."
+	},
+	"MIDI CC2": {
+		"scope": "sfz",
+		"prefix": "cc002: Breath Controller",
+		"body": "cc2=$0",
+		"description": "MIDI CC for breath controller."
+	},
+	"MIDI CC3": {
+		"scope": "sfz",
+		"prefix": "cc003: ...",
+		"body": "cc3=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC4": {
+		"scope": "sfz",
+		"prefix": "cc004: Foot Controller",
+		"body": "cc4=$0",
+		"description": "MIDI CC for foot controller."
+	},
+	"MIDI CC5": {
+		"scope": "sfz",
+		"prefix": "cc005: Portamento Time",
+		"body": "cc5=$0",
+		"description": "MIDI CC for portamento time."
+	},
+	"MIDI CC6": {
+		"scope": "sfz",
+		"prefix": "cc006: Data Entry MSB",
+		"body": "cc6=$0",
+		"description": "MIDI CC for data entry MSB."
+	},
+	"MIDI CC7": {
+		"scope": "sfz",
+		"prefix": "cc007: Channel Volume",
+		"body": "cc7=$0",
+		"description": "MIDI CC for channel volume."
+	},
+	"MIDI CC8": {
+		"scope": "sfz",
+		"prefix": "cc008: Balance",
+		"body": "cc8=$0",
+		"description": "MIDI CC for stereo balance."
+	},
+	"MIDI CC9": {
+		"scope": "sfz",
+		"prefix": "cc009: ...",
+		"body": "cc9=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC10": {
+		"scope": "sfz",
+		"prefix": "cc010: Pan",
+		"body": "cc10=$0",
+		"description": "MIDI CC for pan position."
+	},
+	"MIDI CC11": {
+		"scope": "sfz",
+		"prefix": "cc011: Expression Controller",
+		"body": "cc11=$0",
+		"description": "MIDI CC for expression controller."
+	},
+	"MIDI CC12": {
+		"scope": "sfz",
+		"prefix": "cc012: Effect Control 1",
+		"body": "cc12=$0",
+		"description": "MIDI CC for effect control 1."
+	},
+	"MIDI CC13": {
+		"scope": "sfz",
+		"prefix": "cc013: Effect Control 2",
+		"body": "cc13=$0",
+		"description": "MIDI CC for effect control 2."
+	},
+	"MIDI CC14": {
+		"scope": "sfz",
+		"prefix": "cc014: ...",
+		"body": "cc14=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC15": {
+		"scope": "sfz",
+		"prefix": "cc015: ...",
+		"body": "cc15=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC16": {
+		"scope": "sfz",
+		"prefix": "cc016: General Purpose Controller 1",
+		"body": "cc16=$0",
+		"description": "MIDI CC for general purpose controller 1."
+	},
+	"MIDI CC17": {
+		"scope": "sfz",
+		"prefix": "cc017: General Purpose Controller 2",
+		"body": "cc17=$0",
+		"description": "MIDI CC for general purpose controller 2."
+	},
+	"MIDI CC18": {
+		"scope": "sfz",
+		"prefix": "cc018: General Purpose Controller 3",
+		"body": "cc18=$0",
+		"description": "MIDI CC for general purpose controller 3."
+	},
+	"MIDI CC19": {
+		"scope": "sfz",
+		"prefix": "cc019: General Purpose Controller 4",
+		"body": "cc19=$0",
+		"description": "MIDI CC for general purpose controller 4."
+	},
+	"MIDI CC20": {
+		"scope": "sfz",
+		"prefix": "cc020: ...",
+		"body": "cc20=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC21": {
+		"scope": "sfz",
+		"prefix": "cc021: ...",
+		"body": "cc21=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC22": {
+		"scope": "sfz",
+		"prefix": "cc022: ...",
+		"body": "cc22=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC23": {
+		"scope": "sfz",
+		"prefix": "cc023: ...",
+		"body": "cc23=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC24": {
+		"scope": "sfz",
+		"prefix": "cc024: ...",
+		"body": "cc24=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC25": {
+		"scope": "sfz",
+		"prefix": "cc025: ...",
+		"body": "cc25=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC26": {
+		"scope": "sfz",
+		"prefix": "cc026: ...",
+		"body": "cc26=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC27": {
+		"scope": "sfz",
+		"prefix": "cc027: ...",
+		"body": "cc27=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC28": {
+		"scope": "sfz",
+		"prefix": "cc028: ...",
+		"body": "cc28=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC29": {
+		"scope": "sfz",
+		"prefix": "cc029: ...",
+		"body": "cc29=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC30": {
+		"scope": "sfz",
+		"prefix": "cc030: ...",
+		"body": "cc30=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC31": {
+		"scope": "sfz",
+		"prefix": "cc031: ...",
+		"body": "cc31=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC32": {
+		"scope": "sfz",
+		"prefix": "cc032: CC0 LSB (Bank Select)",
+		"body": "cc32=$0",
+		"description": "MIDI CC for bank select (fine)."
+	},
+	"MIDI CC33": {
+		"scope": "sfz",
+		"prefix": "cc033: CC1 LSB (Modulation Wheel)",
+		"body": "cc33=$0",
+		"description": "MIDI CC for modulation wheel fine adjustment."
+	},
+	"MIDI CC34": {
+		"scope": "sfz",
+		"prefix": "cc034: CC2 LSB (Breath Controller)",
+		"body": "cc34=$0",
+		"description": "MIDI CC for breath controller fine adjustment."
+	},
+	"MIDI CC35": {
+		"scope": "sfz",
+		"prefix": "cc035: CC3 LSB (...)",
+		"body": "cc35=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC36": {
+		"scope": "sfz",
+		"prefix": "cc036: CC4 LSB (Foot Controller)",
+		"body": "cc36=$0",
+		"description": "MIDI CC for foot pedal (fine)."
+	},
+	"MIDI CC37": {
+		"scope": "sfz",
+		"prefix": "cc037: CC5 LSB (Portamento Time)",
+		"body": "cc37=$0",
+		"description": "MIDI CC for portamento time (fine)."
+	},
+	"MIDI CC38": {
+		"scope": "sfz",
+		"prefix": "cc038: CC6 LSB (Data Entry)",
+		"body": "cc38=$0",
+		"description": "MIDI CC for data entry (fine)."
+	},
+	"MIDI CC39": {
+		"scope": "sfz",
+		"prefix": "cc039: CC7 LSB (Channel Volume)",
+		"body": "cc39=$0",
+		"description": "MIDI CC for volume (fine)."
+	},
+	"MIDI CC40": {
+		"scope": "sfz",
+		"prefix": "cc040: CC8 LSB (Balance)",
+		"body": "cc40=$0",
+		"description": "MIDI CC for balance (fine)."
+	},
+	"MIDI CC41": {
+		"scope": "sfz",
+		"prefix": "cc041: CC9 LSB (...)",
+		"body": "cc41=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC42": {
+		"scope": "sfz",
+		"prefix": "cc042: CC10 LSB (Pan)",
+		"body": "cc42=$0",
+		"description": "MIDI CC for pan position (fine)."
+	},
+	"MIDI CC43": {
+		"scope": "sfz",
+		"prefix": "cc043: CC11 LSB (Expression Controller)",
+		"body": "cc43=$0",
+		"description": "MIDI CC for expression (fine)."
+	},
+	"MIDI CC44": {
+		"scope": "sfz",
+		"prefix": "cc044: CC12 LSB (Effect Control 1)",
+		"body": "cc44=$0",
+		"description": "MIDI CC for effect control 1 (fine)."
+	},
+	"MIDI CC45": {
+		"scope": "sfz",
+		"prefix": "cc045: CC13 LSB (Effect Control 2)",
+		"body": "cc45=$0",
+		"description": "MIDI CC for effect control 2 (fine)."
+	},
+	"MIDI CC46": {
+		"scope": "sfz",
+		"prefix": "cc046: CC14 LSB (...)",
+		"body": "cc46=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC47": {
+		"scope": "sfz",
+		"prefix": "cc047: CC15 LSB (...)",
+		"body": "cc47=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC48": {
+		"scope": "sfz",
+		"prefix": "cc048: CC16 LSB (General Purpose Controller 1)",
+		"body": "cc48=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC49": {
+		"scope": "sfz",
+		"prefix": "cc049: CC17 LSB (General Purpose Controller 2)",
+		"body": "cc49=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC50": {
+		"scope": "sfz",
+		"prefix": "cc050: CC18 LSB (General Purpose Controller 3)",
+		"body": "cc50=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC51": {
+		"scope": "sfz",
+		"prefix": "cc051: CC19 LSB (General Purpose Controller 4)",
+		"body": "cc51=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC52": {
+		"scope": "sfz",
+		"prefix": "cc052: CC20 LSB (...)",
+		"body": "cc52=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC53": {
+		"scope": "sfz",
+		"prefix": "cc053: CC21 LSB (...)",
+		"body": "cc53=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC54": {
+		"scope": "sfz",
+		"prefix": "cc054: CC22 LSB (...)",
+		"body": "cc54=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC55": {
+		"scope": "sfz",
+		"prefix": "cc055: CC23 LSB (...)",
+		"body": "cc55=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC56": {
+		"scope": "sfz",
+		"prefix": "cc056: CC24 LSB (...)",
+		"body": "cc56=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC57": {
+		"scope": "sfz",
+		"prefix": "cc057: CC25 LSB (...)",
+		"body": "cc57=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC58": {
+		"scope": "sfz",
+		"prefix": "cc058: CC26 LSB (...)",
+		"body": "cc58=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC59": {
+		"scope": "sfz",
+		"prefix": "cc059: CC27 LSB (...)",
+		"body": "cc59=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC60": {
+		"scope": "sfz",
+		"prefix": "cc060: CC28 LSB (...)",
+		"body": "cc60=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC61": {
+		"scope": "sfz",
+		"prefix": "cc061: CC29 LSB (...)",
+		"body": "cc61=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC62": {
+		"scope": "sfz",
+		"prefix": "cc062: CC30 LSB (...)",
+		"body": "cc62=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC63": {
+		"scope": "sfz",
+		"prefix": "cc063: CC31 LSB (...)",
+		"body": "cc63=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC64": {
+		"scope": "sfz",
+		"prefix": "cc064: Sustain Pedal (on/off)",
+		"body": "cc64=$0",
+		"description": "MIDI CC for damper/sustain/hold pedal (on/off)."
+	},
+	"MIDI CC65": {
+		"scope": "sfz",
+		"prefix": "cc065: Portamento (on/off)",
+		"body": "cc65=$0",
+		"description": "MIDI CC for portamento (on/off)."
+	},
+	"MIDI CC66": {
+		"scope": "sfz",
+		"prefix": "cc066: Sostenuto (on/off)",
+		"body": "cc66=$0",
+		"description": "MIDI CC for sostenuto pedal (on/off)."
+	},
+	"MIDI CC67": {
+		"scope": "sfz",
+		"prefix": "cc067: Soft Pedal (on/off)",
+		"body": "cc67=$0",
+		"description": "MIDI CC for soft pedal (on/off)."
+	},
+	"MIDI CC68": {
+		"scope": "sfz",
+		"prefix": "cc068: Legato Footswitch (on/off)",
+		"body": "cc68=$0",
+		"description": "MIDI CC for legato footswitch (on/off)."
+	},
+	"MIDI CC69": {
+		"scope": "sfz",
+		"prefix": "cc069: Hold 2 (on/off)",
+		"body": "cc69=$0",
+		"description": "MIDI CC for hold 2 (on/off)."
+	},
+	"MIDI CC70": {
+		"scope": "sfz",
+		"prefix": "cc070: Sound Control 1 (Variation)",
+		"body": "cc70=$0",
+		"description": "MIDI CC for sound variation."
+	},
+	"MIDI CC71": {
+		"scope": "sfz",
+		"prefix": "cc071: Sound Control 2 (Timbre / Filter Resonance)",
+		"body": "cc71=$0",
+		"description": "MIDI CC for sound timbre (typically filter resonance)."
+	},
+	"MIDI CC72": {
+		"scope": "sfz",
+		"prefix": "cc072: Sound Control 3 (Release Time)",
+		"body": "cc72=$0",
+		"description": "MIDI CC for sound control 3 (typically amp envelope release time)."
+	},
+	"MIDI CC73": {
+		"scope": "sfz",
+		"prefix": "cc073: Sound Control 4 (Attack Time)",
+		"body": "cc73=$0",
+		"description": "MIDI CC for sound control 4 (typically amp envelope attack time)."
+	},
+	"MIDI CC74": {
+		"scope": "sfz",
+		"prefix": "cc074: Sound Control 5 (Brightness / Filter Frequency)",
+		"body": "cc74=$0",
+		"description": "MIDI CC for sound control 5 (typically filter frequency)."
+	},
+	"MIDI CC75": {
+		"scope": "sfz",
+		"prefix": "cc075: Sound Control 6 (Decay Time)",
+		"body": "cc75=$0",
+		"description": "MIDI CC for sound control 6 (typically amp envelope decay time)."
+	},
+	"MIDI CC76": {
+		"scope": "sfz",
+		"prefix": "cc076: Sound Control 7 (Vibrato Rate)",
+		"body": "cc76=$0",
+		"description": "MIDI CC for sound control 7 (typically vibrato rate)."
+	},
+	"MIDI CC77": {
+		"scope": "sfz",
+		"prefix": "cc077: Sound Control 8 (Vibrato Depth)",
+		"body": "cc77=$0",
+		"description": "MIDI CC for sound control 8 (typically vibrato depth)."
+	},
+	"MIDI CC78": {
+		"scope": "sfz",
+		"prefix": "cc078: Sound Control 9 (Vibrato Delay)",
+		"body": "cc78=$0",
+		"description": "MIDI CC for sound control 9 (typically vibrato delay)."
+	},
+	"MIDI CC79": {
+		"scope": "sfz",
+		"prefix": "cc079: Sound Control 10 (...)",
+		"body": "cc79=$0",
+		"description": "MIDI CC for sound control 10 (typically undefined)."
+	},
+	"MIDI CC80": {
+		"scope": "sfz",
+		"prefix": "cc080: General Purpose Controller 5",
+		"body": "cc80=$0",
+		"description": "MIDI CC for general purpose controller 5."
+	},
+	"MIDI CC81": {
+		"scope": "sfz",
+		"prefix": "cc081: General Purpose Controller 6",
+		"body": "cc81=$0",
+		"description": "MIDI CC for general purpose controller 6."
+	},
+	"MIDI CC82": {
+		"scope": "sfz",
+		"prefix": "cc082: General Purpose Controller 7",
+		"body": "cc82=$0",
+		"description": "MIDI CC for general purpose controller 7."
+	},
+	"MIDI CC83": {
+		"scope": "sfz",
+		"prefix": "cc083: General Purpose Controller 8",
+		"body": "cc83=$0",
+		"description": "MIDI CC for general purpose controller 8."
+	},
+	"MIDI CC84": {
+		"scope": "sfz",
+		"prefix": "cc084: Portamento Control",
+		"body": "cc84=$0",
+		"description": "MIDI CC for portamento control."
+	},
+	"MIDI CC85": {
+		"scope": "sfz",
+		"prefix": "cc085: ...",
+		"body": "cc85=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC86": {
+		"scope": "sfz",
+		"prefix": "cc086: ...",
+		"body": "cc86=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC87": {
+		"scope": "sfz",
+		"prefix": "cc087: ...",
+		"body": "cc87=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC88": {
+		"scope": "sfz",
+		"prefix": "cc088: High Resolution Velocity Prefix",
+		"body": "cc88=$0",
+		"description": "MIDI CC for high resolution velocity prefix."
+	},
+	"MIDI CC89": {
+		"scope": "sfz",
+		"prefix": "cc089: ...",
+		"body": "cc89=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC90": {
+		"scope": "sfz",
+		"prefix": "cc090: ...",
+		"body": "cc90=$0",
+		"description": "Typically free MIDI CC."
+	},
+
+	"MIDI CC91": {
+		"scope": "sfz",
+		"prefix": "cc091: Effects 1 Depth (Reverb)",
+		"body": "cc91=$0",
+		"description": "MIDI CC for effects 1 depth (typically reverb send level)."
+	},
+	"MIDI CC92": {
+		"scope": "sfz",
+		"prefix": "cc092: Effects 2 Depth (Tremolo)",
+		"body": "cc92=$0",
+		"description": "MIDI CC for Effects 2 Depth (formerly Tremolo Depth)."
+	},
+	"MIDI CC93": {
+		"scope": "sfz",
+		"prefix": "cc093: Effects 3 Depth (Chorus)",
+		"body": "cc93=$0",
+		"description": "MIDI CC for Effects 3 Depth (typically chorus send level)."
+	},
+	"MIDI CC94": {
+		"scope": "sfz",
+		"prefix": "cc094: Effects 4 Depth (Celeste/Detune)",
+		"body": "cc94=$0",
+		"description": "MIDI CC for Effects 4 Depth (formerly Celeste [Detune] Depth)."
+	},
+	"MIDI CC95": {
+		"scope": "sfz",
+		"prefix": "cc095: Effects 5 Depth (Phaser)",
+		"body": "cc95=$0",
+		"description": "MIDI CC for Effects 5 Depth (formerly Phaser Depth)."
+	},
+	"MIDI CC96": {
+		"scope": "sfz",
+		"prefix": "cc096: Data Increment",
+		"body": "cc96=$0",
+		"description": "MIDI CC for Data Increment (Data Entry +1)."
+	},
+	"MIDI CC97": {
+		"scope": "sfz",
+		"prefix": "cc097: Data Decrement",
+		"body": "cc97=$0",
+		"description": "MIDI CC for Data Decrement (Data Entry -1)."
+	},
+	"MIDI CC98": {
+		"scope": "sfz",
+		"prefix": "cc098: NPRN (LSB)",
+		"body": "cc98=$0",
+		"description": "MIDI CC for Non-Registered Parameter Number LSB."
+	},
+	"MIDI CC99": {
+		"scope": "sfz",
+		"prefix": "cc099: NRPN (MSB)",
+		"body": "cc99=$0",
+		"description": "MIDI CC for Non-Registered Parameter Number MSB."
+	},
+	"MIDI CC100": {
+		"scope": "sfz",
+		"prefix": "cc100: RPN (LSB)",
+		"body": "cc100=$0",
+		"description": "MIDI CC for Registered Parameter Number LSB."
+	},
+	"MIDI CC101": {
+		"scope": "sfz",
+		"prefix": "cc101: RPN (MSB)",
+		"body": "cc101=$0",
+		"description": "MIDI CC for Registered Parameter Number MSB."
+	},
+
+	"MIDI CC102": {
+		"scope": "sfz",
+		"prefix": "cc102: ...",
+		"body": "cc102=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC103": {
+		"scope": "sfz",
+		"prefix": "cc103: ...",
+		"body": "cc103=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC104": {
+		"scope": "sfz",
+		"prefix": "cc104: ...",
+		"body": "cc104=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC105": {
+		"scope": "sfz",
+		"prefix": "cc105: ...",
+		"body": "cc105=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC106": {
+		"scope": "sfz",
+		"prefix": "cc106: ...",
+		"body": "cc106=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC107": {
+		"scope": "sfz",
+		"prefix": "cc107: ...",
+		"body": "cc107=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC108": {
+		"scope": "sfz",
+		"prefix": "cc108: ...",
+		"body": "cc108=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC109": {
+		"scope": "sfz",
+		"prefix": "cc109: ...",
+		"body": "cc109=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC110": {
+		"scope": "sfz",
+		"prefix": "cc110: ...",
+		"body": "cc110=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC111": {
+		"scope": "sfz",
+		"prefix": "cc111: ...",
+		"body": "cc111=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC112": {
+		"scope": "sfz",
+		"prefix": "cc112: ...",
+		"body": "cc112=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC113": {
+		"scope": "sfz",
+		"prefix": "cc113: ...",
+		"body": "cc113=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC114": {
+		"scope": "sfz",
+		"prefix": "cc114: ...",
+		"body": "cc114=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC115": {
+		"scope": "sfz",
+		"prefix": "cc115: ...",
+		"body": "cc115=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC116": {
+		"scope": "sfz",
+		"prefix": "cc116: ...",
+		"body": "cc116=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC117": {
+		"scope": "sfz",
+		"prefix": "cc117: ...",
+		"body": "cc117=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC118": {
+		"scope": "sfz",
+		"prefix": "cc118: ...",
+		"body": "cc118=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC119": {
+		"scope": "sfz",
+		"prefix": "cc119: ...",
+		"body": "cc119=$0",
+		"description": "Typically free MIDI CC."
+	},
+	"MIDI CC120": {
+		"scope": "sfz",
+		"prefix": "cc120: All Sound Off",
+		"body": "cc120=$0",
+		"description": "MIDI CC for all sound off."
+	},
+	"MIDI CC121": {
+		"scope": "sfz",
+		"prefix": "cc121: All Controllers Off",
+		"body": "cc121=$0",
+		"description": "MIDI CC for all controllers off."
+	},
+	"MIDI CC122": {
+		"scope": "sfz",
+		"prefix": "cc122: Local Control On/Off",
+		"body": "cc122=$0",
+		"description": "MIDI CC for local control on/off."
+	},
+	"MIDI CC123": {
+		"scope": "sfz",
+		"prefix": "cc123: All Notes Off",
+		"body": "cc123=$0",
+		"description": "MIDI CC for all notes off."
+	},
+	"MIDI CC124": {
+		"scope": "sfz",
+		"prefix": "cc124: Omni Mode Off",
+		"body": "cc124=$0",
+		"description": "MIDI CC for omni mode off (plus all notes off)."
+	},
+	"MIDI CC125": {
+		"scope": "sfz",
+		"prefix": "cc125: Omni Mode On",
+		"body": "cc125=$0",
+		"description": "MIDI CC for omni mode on (plus all notes off)."
+	},
+	"MIDI CC126": {
+		"scope": "sfz",
+		"prefix": "cc126: Mono Mode On",
+		"body": "cc126=$0",
+		"description": "MIDI CC for Mono Mode On (+Poly Mode Off, +All Notes Off)."
+	},
+	"MIDI CC127": {
+		"scope": "sfz",
+		"prefix": "cc127: Poly Mode On",
+		"body": "cc127=$0",
+		"description": "MIDI CC for Poly Mode On (+Mono Mode Off, +All Notes Off)."
+	},	
+	"SFZv2 CC128": {
+		"scope": "sfz",
+		"prefix": "cc128: Pitch Bend",
+		"body": "cc128=$0",
+		"description": "SFZ v2 CC for pitch bend."
+	},
+	"SFZv2 CC129": {
+		"scope": "sfz",
+		"prefix": "cc129: Channel Aftertouch",
+		"body": "cc129=$0",
+		"description": "SFZ v2 CC for Channel Aftertouch."
+	},
+	"SFZv2 CC130": {
+		"scope": "sfz",
+		"prefix": "cc130: Polyphonic Aftertouch",
+		"body": "cc130=$0",
+		"description": "SFZ v2 CC for Polyphonic Aftertouch."
+	},
+	"SFZv2 CC131": {
+		"scope": "sfz",
+		"prefix": "cc131: Note-On Velocity",
+		"body": "cc131=$0",
+		"description": "SFZ v2 CC for Note-on Velocity."
+	},
+	"SFZv2 CC132": {
+		"scope": "sfz",
+		"prefix": "cc132: Note-Off Velocity",
+		"body": "cc132=$0",
+		"description": "SFZ v2 CC for Note-off Velocity."
+	},
+	"SFZv2 CC133": {
+		"scope": "sfz",
+		"prefix": "cc133: Note Number",
+		"body": "cc133=$0",
+		"description": "SFZ v2 CC for Note Number."
+	},
+	"SFZv2 CC134": {
+		"scope": "sfz",
+		"prefix": "cc134: Note Gate",
+		"body": "cc134=$0",
+		"description": "SFZ v2 CC for Note Gate. 0 = no notes pressed, 1 = >0 notes pressed."
+	},
+	"SFZv2 CC135": {
+		"scope": "sfz",
+		"prefix": "cc135: Unipolar Random",
+		"body": "cc135=$0",
+		"description": "SFZ v2 CC for Unipolar Random (yields values between 0 and 1)."
+	},
+	"SFZv2 CC136": {
+		"scope": "sfz",
+		"prefix": "cc136: Bipolar Random",
+		"body": "cc136=$0",
+		"description": "SFZ v2 CC for Bipolar Random (yields values between -1 and 1)."
+	},
+	"SFZv2 CC137": {
+		"scope": "sfz",
+		"prefix": "cc137: Alternate",
+		"body": "cc137=$0",
+		"description": "SFZ v2 CC for Alternate (yields alternating values of 0 and 1 with each note-on event)."
+	},
+	"ARIA CC140": {
+		"scope": "sfz",
+		"prefix": "cc140: Key Delta (Relative)",
+		"body": "cc140=$0",
+		"description": "ARIA CC for relative key delta (yields the distance in notes from last note-on to new note-on)."
+	},
+	"ARIA CC141": {
+		"scope": "sfz",
+		"prefix": "cc141: Key Delta (Absolute)",
+		"body": "cc141=$0",
+		"description": "ARIA CC for absolute key delta."
+	},
+	"ARIA CC142": {
+		"scope": "sfz",
+		"prefix": "cc142: Host Tempo (BPM)",
+		"body": "cc142=$0",
+		"description": "ARIA CC for host tempo expressed in Beats Per Minute."
+	},
+	"ARIA CC143": {
+		"scope": "sfz",
+		"prefix": "cc143: Host Transport Status",
+		"body": "cc143=$0",
+		"description": "ARIA CC for host transport status where 0 = stopped, 1 = playing in non-loop mode, 2 = playing in loop mode."
+	},
+	"ARIA CC144": {
+		"scope": "sfz",
+		"prefix": "cc144: Host Sample Rate",
+		"body": "cc144=$0",
+		"description": "ARIA CC for host sample rate."
+	},
+	"ARIA CC145": {
+		"scope": "sfz",
+		"prefix": "cc145: Engine Uptime",
+		"body": "cc145=$0",
+		"description": "ARIA CC for time since the engine has been up."
+	},
+	"ARIA CC146": {
+		"scope": "sfz",
+		"prefix": "cc146: Time Signature Numerator",
+		"body": "cc146=$0",
+		"description": "ARIA CC for yielding the current time signature numerator."
+	},
+	"ARIA CC147": {
+		"scope": "sfz",
+		"prefix": "cc147: Time Signature Denominator",
+		"body": "cc147=$0",
+		"description": "ARIA CC for yielding the current time signature denominator."
+	},
+	"ARIA CC148": {
+		"scope": "sfz",
+		"prefix": "cc148: PPQ Since Song Start",
+		"body": "cc148=$0",
+		"description": "ARIA CC for yielding the period elapsed since song start, expressed in PPQ (Pulses Per Quarter note)."
+	},
+	"ARIA CC149": {
+		"scope": "sfz",
+		"prefix": "cc149: PPQ Since Bar Start",
+		"body": "cc149=$0",
+		"description": "ARIA CC for yielding the period elapsed since bar start, expressed in PPQ (Pulses Per Quarter note)."
+	},
+	"ARIA CC150": {
+		"scope": "sfz",
+		"prefix": "cc150: Instrument Uptime (Seconds)",
+		"body": "cc150=$0",
+		"description": "ARIA CC for yielding the time elapsed since instrument instantiation, expressed in seconds."
+	},
+	"ARIA CC151": {
+		"scope": "sfz",
+		"prefix": "cc151: Last Note-On (Seconds)",
+		"body": "cc151=$0",
+		"description": "ARIA CC for yielding the time elapsed since the last note-on event, expressed in seconds."
+	},
+	"ARIA CC152": {
+		"scope": "sfz",
+		"prefix": "cc152: Last Note-Off (Seconds)",
+		"body": "cc152=$0",
+		"description": "ARIA CC for yielding the time elapsed since the last note-off event, expressed in seconds."
+	},
+	"ARIA CC153": {
+		"scope": "sfz",
+		"prefix": "cc153: Total Gates Open",
+		"body": "cc153=$0",
+		"description": "ARIA CC for yielding the cuurent number of keys held down."
+	},
+	"ARIA CC154": {
+		"scope": "sfz",
+		"prefix": "cc154: Total Active Voices",
+		"body": "cc154=$0",
+		"description": "ARIA CC for yielding the current number of active voices."
+	},
+	"ARIA CC155": {
+		"scope": "sfz",
+		"prefix": "cc155: Last Sample Offset",
+		"body": "cc155=$0",
+		"description": "ARIA CC for yielding the playahead (offset) value of the sample triggered most recently in the instrument."
+	}
 }


### PR DESCRIPTION
To serve as reference and autocomplete for SFZv1, SFZv2 and ARIA opcodes, plus standard MIDI, SFZv2 and ARIA CC numbers.