### PR TITLE
Sample opcode may share a line with other opcodes

### DIFF
--- a/syntaxes/sfz.tmLanguage.json
+++ b/syntaxes/sfz.tmLanguage.json
@@ -76,7 +76,7 @@
 						"1": { "name": "variable.language.sound-source.$1.sfz" },
 						"2": { "name": "keyword.operator.assignment.sfz" }
 					},
-					"end": "(?=(\\s\/\/|$))",
+					"end": "(?=(\\s\\S+=|\\s\/\/|$))",
 					"contentName": "string.unquoted.sfz"
 				},
 				{ "comment": "opcodes: (delay|delay_random|delay_onccN): (0 to 100 percent)",


### PR DESCRIPTION
Not sure if this change is perfect but it does provide clearer highlighting in those cases.